### PR TITLE
Add custom aliases for books

### DIFF
--- a/src/__tests__/findBook.test.ts
+++ b/src/__tests__/findBook.test.ts
@@ -68,4 +68,16 @@ describe('findBook', () => {
     expect(findBook(' gen ', 'E')).toEqual(expect.objectContaining({ id: 1 }));
     expect(findBook(' 1 moo ', 'FI')).toEqual(expect.objectContaining({ id: 1 }));
   });
+
+  test('considers user-defined custom aliases', () => {
+    const customAliases = [{ bookId: 66, alias: 'rev' }];
+    expect(findBook('rev', 'X', customAliases)).toEqual(expect.objectContaining({ id: 66 }));
+  });
+
+  test('merges user-defined custom aliases with predefined aliases', () => {
+    const customAliases = [{ bookId: 66, alias: 'rev' }];
+    const book = findBook('rev', 'X', customAliases);
+    expect(book).toEqual(expect.objectContaining({ id: 66 }));
+    expect(book.aliases).toContain('rev');
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export type Language = 'E' | 'X' | 'FI'; // plugin language
 export interface LinkReplacerSettings {
   useShortNames: boolean;
   language: Language;
+  customAliases: CustomAlias[];
 }
 
 export interface BibleBook {
@@ -39,4 +40,9 @@ export interface BibleSuggestion {
   command: 'formatBook' | 'link' | 'open' | 'typing';
   description: string;
   linkIndex?: number;
+}
+
+export interface CustomAlias {
+  bookId: number;
+  alias: string;
 }

--- a/src/utils/findBook.ts
+++ b/src/utils/findBook.ts
@@ -1,7 +1,7 @@
 import { getBibleBooks } from '@/bibleBooks';
 import type { BibleBook, Language } from '@/types';
 
-export const findBook = (bookQuery: string, language: Language): BibleBook | BibleBook[] => {
+export const findBook = (bookQuery: string, language: Language, customAliases: { bookId: number; alias: string }[] = []): BibleBook | BibleBook[] => {
   const trimmedQuerry = bookQuery
     .toLowerCase()
     .replace(/[/.\s]/g, '')
@@ -17,7 +17,18 @@ export const findBook = (bookQuery: string, language: Language): BibleBook | Bib
     throw new Error('errors.bookNotFound');
   }
 
-  const bookEntries = bibleBooks
+  const mergedBooks = bibleBooks.map((book) => {
+    const customAlias = customAliases.find((alias) => alias.bookId === book.id);
+    if (customAlias) {
+      return {
+        ...book,
+        aliases: [...book.aliases, customAlias.alias],
+      };
+    }
+    return book;
+  });
+
+  const bookEntries = mergedBooks
     .filter((book) => (!book.prefix ? true : trimmedQuerry.match(/^[1-5]/)))
     .filter((book) => {
       const alias = book.aliases.map((alias) => (book.prefix ? `${book.prefix}${alias}` : alias));


### PR DESCRIPTION
Add functionality to allow users to define custom aliases for books.

* Add a new setting for custom aliases in `JWLibraryLinkerSettings` class in `src/main.ts`.
* Add a method `addCustomAlias` to `JWLibraryLinkerPlugin` in `src/main.ts` to handle custom aliases.
* Update `loadSettings` and `saveSettings` methods in `src/main.ts` to include custom aliases.
* Add a dialog in the settings view in `src/main.ts` to manage custom aliases.
* Update `findBook` function in `src/utils/findBook.ts` to consider user-defined custom aliases.
* Merge user-defined custom aliases with predefined aliases in `src/utils/findBook.ts`.
* Add a new type `CustomAlias` in `src/types.ts` to represent user-defined custom aliases.
* Update `LinkReplacerSettings` interface in `src/types.ts` to include custom aliases.
* Add test cases in `src/__tests__/findBook.test.ts` to verify that `findBook` considers user-defined custom aliases and merges them with predefined aliases.

