### PR TITLE
add token to checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.USER_TOKEN }}
 
       - name: Install changesets cli
         run: npm i -D @changesets/cli @changesets/changelog-github


### PR DESCRIPTION
Sorry for the repeating PRs for the changeset.
This one hopfully will be the last.
I found this: 
> When the action calls git push, it uses the same token as the one that was used during checkout. This explains why setting GITHUB_TOKEN only in changesets/action does not change the account that has force-pushed.
https://github.com/changesets/action/issues/187#issuecomment-1228413850

This also meant the push to the changeset-release/main branch did not trigger the test workflow 🤷‍♂️