### PR TITLE
fix: close suggestion box after text replacement

### DIFF
--- a/.changeset/calm-nights-bet.md
+++ b/.changeset/calm-nights-bet.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+fix suggestion box staying open with italic link style on macOS

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ main.js
 # Development
 .idea/
 .vscode/
+.claude/
 *.log
 
 # OS-specific files

--- a/src/BibleReferenceSuggester.ts
+++ b/src/BibleReferenceSuggester.ts
@@ -188,6 +188,9 @@ export class BibleReferenceSuggester extends EditorSuggest<BibleSuggestion> {
     // Replace the entire command and reference with the converted link
     editor.replaceRange(convertedLink, context.start, context.end);
 
+    // Force close the suggestion box to prevent it from staying open with italic formatting
+    this.close();
+
     // Handle opening links
     if (suggestion.command === 'open') {
       const url = formatJWLibraryLink(reference, linkLanguage);


### PR DESCRIPTION
When link style is set to italic, the suggestion box would stay open on macOS after selecting a suggestion, preventing normal line breaks. This adds an explicit close() call after text replacement to ensure the suggestion box is properly dismissed regardless of formatting style.

Fixes issue where italic markdown formatting (*text*) interfered with suggestion box state management on desktop platforms.