### PR TITLE
fix: whitelist pnpm native build scripts to prevent corrupted node_modules

### DIFF
--- a/.changeset/fix-pnpm-build-scripts.md
+++ b/.changeset/fix-pnpm-build-scripts.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+Whitelist native build scripts for @swc/core, esbuild, and unrs-resolver to prevent corrupted node_modules on fresh installs.

--- a/package.json
+++ b/package.json
@@ -51,5 +51,12 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.0"
   },
-  "packageManager": "pnpm@10.27.0+sha512.72d699da16b1179c14ba9e64dc71c9a40988cbdc65c264cb0e489db7de917f20dcf4d64d8723625f2969ba52d4b7e2a1170682d9ac2a5dcaeaab732b7e16f04a"
+  "packageManager": "pnpm@10.27.0+sha512.72d699da16b1179c14ba9e64dc71c9a40988cbdc65c264cb0e489db7de917f20dcf4d64d8723625f2969ba52d4b7e2a1170682d9ac2a5dcaeaab732b7e16f04a",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@swc/core",
+      "esbuild",
+      "unrs-resolver"
+    ]
+  }
 }


### PR DESCRIPTION
pnpm silently skips postinstall scripts for @swc/core, esbuild, and unrs-resolver unless explicitly approved. This caused empty @types directories and build failures after fresh installs.