### PR TITLE
feat: czech language support + Windows build fixes + Fix plugin setting always in English

### DIFF
--- a/.changeset/feat-czech-language-support.md
+++ b/.changeset/feat-czech-language-support.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': minor
+---
+
+Add Czech language support (JW Library code `B`). Includes Czech Bible book names, abbreviations, and UI translations.

--- a/.changeset/fix-locale-detection-moment.md
+++ b/.changeset/fix-locale-detection-moment.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+Fix UI locale detection by reading from `window.moment.locale()` instead of `localStorage.language`, which Obsidian does not use.

--- a/.changeset/fix-windows-dev-script.md
+++ b/.changeset/fix-windows-dev-script.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+Fix `pnpm dev` on Windows by using cross-env for setting the DEBUG environment variable.

--- a/.changeset/fix-windows-locale-bundle-paths.md
+++ b/.changeset/fix-windows-locale-bundle-paths.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+Fix locale bundle keys using backslashes on Windows, which caused the plugin to fail with "English locale not found in bundle" when built on Windows.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Instantly create, convert, and enrich Bible references with direct links to [JW 
 | Português (Portugal) | TPO |
 | Hrvatski (Croatian) | CR |
 | Việt (Vietnamese) | VT |
+| Čeština (Czech) | B |
 
 The plugin UI automatically adapts to your Obsidian language setting, and Bible book names are fully translated for each language.
 

--- a/esbuild-yaml-plugin.mjs
+++ b/esbuild-yaml-plugin.mjs
@@ -52,7 +52,7 @@ export function yamlPlugin() {
           const fullPath = path.resolve(__dirname, file);
           const yamlContent = fs.readFileSync(fullPath, 'utf8');
           const parsed = yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA });
-          locales[file] = parsed;
+          locales[file.replace(/\\/g, '/')] = parsed;
         }
 
         // Return as ES module

--- a/locale/bibleBooks/B.yaml
+++ b/locale/bibleBooks/B.yaml
@@ -1,0 +1,418 @@
+- id: 1
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Mojžíšova
+    medium: 1. Mo.
+    short: 1Mo
+- id: 2
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Mojžíšova
+    medium: 2. Mo.
+    short: 2Mo
+- id: 3
+  prefix: '3'
+  aliases: []
+  name:
+    long: 3. Mojžíšova
+    medium: 3. Mo.
+    short: 3Mo
+- id: 4
+  prefix: '4'
+  aliases: []
+  name:
+    long: 4. Mojžíšova
+    medium: 4. Mo.
+    short: 4Mo
+- id: 5
+  prefix: '5'
+  aliases: []
+  name:
+    long: 5. Mojžíšova
+    medium: 5. Mo.
+    short: 5Mo
+- id: 6
+  aliases: []
+  name:
+    long: Jozue
+    medium: Joz.
+    short: Joz
+- id: 7
+  aliases: []
+  name:
+    long: Soudci
+    medium: Sou.
+    short: Sd
+- id: 8
+  aliases: []
+  name:
+    long: Rut
+    medium: Rut
+    short: Rut
+- id: 9
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Samuelova
+    medium: 1. Sa.
+    short: 1Sa
+- id: 10
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Samuelova
+    medium: 2. Sa.
+    short: 2Sa
+- id: 11
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Královská
+    medium: 1. Kr.
+    short: 1Kr
+- id: 12
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Královská
+    medium: 2. Kr.
+    short: 2Kr
+- id: 13
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Paralipomenon
+    medium: 1. Pa.
+    short: 1Pa
+- id: 14
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Paralipomenon
+    medium: 2. Pa.
+    short: 2Pa
+- id: 15
+  aliases: []
+  name:
+    long: Ezra
+    medium: Ezra
+    short: Ezr
+- id: 16
+  aliases: []
+  name:
+    long: Nehemjáš
+    medium: Neh.
+    short: Ne
+- id: 17
+  aliases: []
+  name:
+    long: Ester
+    medium: Est.
+    short: Es
+- id: 18
+  aliases: []
+  name:
+    long: Job
+    medium: Job
+    short: Job
+- id: 19
+  aliases: []
+  name:
+    long: Žalmy
+    medium: Ža.
+    short: Ža
+- id: 20
+  aliases: []
+  name:
+    long: Přísloví
+    medium: Přís.
+    short: Př
+- id: 21
+  aliases: []
+  name:
+    long: Kazatel
+    medium: Kaz.
+    short: Ka
+- id: 22
+  aliases: []
+  name:
+    long: Šalomounova píseň
+    medium: Pís.
+    short: Pís
+- id: 23
+  aliases: []
+  name:
+    long: Izajáš
+    medium: Iz.
+    short: Iz
+- id: 24
+  aliases: []
+  name:
+    long: Jeremjáš
+    medium: Jer.
+    short: Jer
+- id: 25
+  aliases: []
+  name:
+    long: Nářky
+    medium: Nář.
+    short: Ná
+- id: 26
+  aliases: []
+  name:
+    long: Ezekiel
+    medium: Eze.
+    short: Ez
+- id: 27
+  aliases: []
+  name:
+    long: Daniel
+    medium: Dan.
+    short: Da
+- id: 28
+  aliases: []
+  name:
+    long: Ozeáš
+    medium: Oz.
+    short: Oz
+- id: 29
+  aliases: []
+  name:
+    long: Joel
+    medium: Joel
+    short: Joe
+- id: 30
+  aliases: []
+  name:
+    long: Amos
+    medium: Amos
+    short: Am
+- id: 31
+  aliases: []
+  name:
+    long: Obadjáš
+    medium: Obj.
+    short: Ob
+- id: 32
+  aliases: []
+  name:
+    long: Jonáš
+    medium: Jon.
+    short: Jon
+- id: 33
+  aliases: []
+  name:
+    long: Micheáš
+    medium: Mi.
+    short: Mi
+- id: 34
+  aliases: []
+  name:
+    long: Nahum
+    medium: Nah.
+    short: Na
+- id: 35
+  aliases: []
+  name:
+    long: Habakuk
+    medium: Hab.
+    short: Hab
+- id: 36
+  aliases: []
+  name:
+    long: Sefanjáš
+    medium: Sef.
+    short: Sef
+- id: 37
+  aliases: []
+  name:
+    long: Ageus
+    medium: Ag.
+    short: Ag
+- id: 38
+  aliases: []
+  name:
+    long: Zecharjáš
+    medium: Zach.
+    short: Ze
+- id: 39
+  aliases: []
+  name:
+    long: Malachiáš
+    medium: Mal.
+    short: Mal
+- id: 40
+  aliases: []
+  name:
+    long: Matouš
+    medium: Mt.
+    short: Mt
+- id: 41
+  aliases: []
+  name:
+    long: Marek
+    medium: Mr.
+    short: Mr
+- id: 42
+  aliases: []
+  name:
+    long: Lukáš
+    medium: Lk.
+    short: Lk
+- id: 43
+  aliases: []
+  name:
+    long: Jan
+    medium: Jan
+    short: Jan
+- id: 44
+  aliases: []
+  name:
+    long: Skutky
+    medium: Sk.
+    short: Sk
+- id: 45
+  aliases: []
+  name:
+    long: Římanům
+    medium: Řím.
+    short: Ří
+- id: 46
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Korinťanům
+    medium: 1. Ko.
+    short: 1Ko
+- id: 47
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Korinťanům
+    medium: 2. Ko.
+    short: 2Ko
+- id: 48
+  aliases: []
+  name:
+    long: Galaťanům
+    medium: Ga.
+    short: Ga
+- id: 49
+  aliases: []
+  name:
+    long: Efezanům
+    medium: Ef.
+    short: Ef
+- id: 50
+  aliases: []
+  name:
+    long: Filipanům
+    medium: Fil.
+    short: Fil
+- id: 51
+  aliases: []
+  name:
+    long: Kolosanům
+    medium: Kol.
+    short: Kol
+- id: 52
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Tesaloničanům
+    medium: 1. Te.
+    short: 1Te
+- id: 53
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Tesaloničanům
+    medium: 2. Te.
+    short: 2Te
+- id: 54
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Timoteovi
+    medium: 1. Ti.
+    short: 1Ti
+- id: 55
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Timoteovi
+    medium: 2. Ti.
+    short: 2Ti
+- id: 56
+  aliases: []
+  name:
+    long: Titovi
+    medium: Tit.
+    short: Tit
+- id: 57
+  aliases: []
+  name:
+    long: Filemonovi
+    medium: Fm.
+    short: Fm
+- id: 58
+  aliases: []
+  name:
+    long: Hebrejcům
+    medium: Heb.
+    short: Heb
+- id: 59
+  aliases: []
+  name:
+    long: Jakub
+    medium: Jak.
+    short: Jk
+- id: 60
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Petra
+    medium: 1. Pe.
+    short: 1Pe
+- id: 61
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Petra
+    medium: 2. Pe.
+    short: 2Pe
+- id: 62
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Jana
+    medium: 1. Ja.
+    short: 1Ja
+- id: 63
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Jana
+    medium: 2. Ja.
+    short: 2Ja
+- id: 64
+  prefix: '3'
+  aliases: []
+  name:
+    long: 3. Jana
+    medium: 3. Ja.
+    short: 3Ja
+- id: 65
+  aliases: []
+  name:
+    long: Juda
+    medium: Juda
+    short: Juda
+- id: 66
+  aliases: []
+  name:
+    long: Zjevení
+    medium: Zj.
+    short: Zj

--- a/locale/cs.yaml
+++ b/locale/cs.yaml
@@ -1,0 +1,103 @@
+settings:
+  language:
+    name: Jazyk
+    description: Vyberte jazyk pro biblické reference
+  openAutomatically:
+    name: Automaticky otevřít odkaz
+    description: Přesune příkaz "Vytvořit odkaz a otevřít" na vrchol seznamu
+  updatedLinkStructure:
+    name: Zachovat text odkazu
+    description: Pokud je zapnuto, aktuální text odkazu bude zachován při převodu biblického textu
+    keepCurrentStructure: Zachovat aktuální strukturu
+    usePluginSettings: Použít nastavení pluginu
+  noLanguageParameter:
+    name: Vytvářet odkazy bez jazykového parametru
+    description: Pokud je zapnuto, jazykový parametr nebude přidán do odkazu. Odkaz se otevře v jazyce aplikace JW Library
+  reconvertExistingLinks:
+    name: Znovu převést existující odkazy
+    description: Pokud je zapnuto, již převedené jwlibrary:// odkazy budou znovu převedeny podle aktuálního nastavení formátování. Umožňuje aktualizovat všechny odkazy podle nejnovějších preferencí.
+  bookLength:
+    name: Délka textu odkazu
+    description: Vyberte délku textu odkazu
+    short: Krátký
+    medium: Střední
+    long: Dlouhý
+  linkStyling:
+    name: Styl odkazu
+    description: Vyberte znaky nebo emoji pro přidání před, za nebo do odkazu; vyberte styl písma
+    reset: 'Obnovit výchozí: "{{default}}"'
+    prefixOutsideLink:
+      name: Předpona mimo odkaz
+      description: Text přidaný před odkaz
+    prefixInsideLink:
+      name: Předpona uvnitř odkazu
+      description: Text přidaný na začátek textu odkazu
+    suffixInsideLink:
+      name: Přípona uvnitř odkazu
+      description: Text přidaný na konec textu odkazu
+    suffixOutsideLink:
+      name: Přípona mimo odkaz
+      description: Text přidaný za odkaz
+    presets:
+      name: Přednastavené styly
+      description: Vyberte přednastavený styl odkazu
+    fontStyle:
+      name: Styl písma
+      description: Vyberte styl písma pro text odkazu
+      normal: Normální
+      italic: Kurzíva
+      bold: Tučné
+    preview:
+      name: Náhled odkazu
+  bibleQuote:
+    name: Formátování biblické citace
+    description: Nakonfigurujte formátování biblických citací při vkládání
+    presets:
+      name: Přednastavené šablony
+      short: Odkaz + citace
+      plain: Odkaz v citaci
+      foldable: Sbalitelný blok
+      expanded: Rozbalený blok
+    template:
+      name: Šablona citace
+      description: 'Přizpůsobte formát citace pomocí proměnných: {bibleRef}, {bibleRefLinked}, {quote}'
+    preview:
+      name: Náhled biblické citace
+commands:
+  linkUnlinkedBibleReferences: Propojit neodkazované biblické reference
+  convertToJWLibraryLinks: Převést odkazy ve výběru na JW Library odkazy
+  insertBibleQuotes: Vložit biblické citace pro JW Library odkazy
+  insertBibleQuoteAtCursor: Vložit biblickou citaci na pozici kurzoru
+convertSuggester:
+  emptyStateText: Vyberte typ převodu
+  options:
+    all: Vše
+    bible: Biblické reference
+    publication: Publikace
+contextMenu:
+  insertBibleQuote: Vložit biblickou citaci
+notices:
+  convertedBibleReferences: 'Převedeno {{count}} biblických referencí'
+  pleaseSelectText: Prosím vyberte text k převodu
+  noBibleReferencesFound: Nebyly nalezeny žádné biblické reference
+  bibleQuotesInserted: Biblické citace úspěšně vloženy
+  bibleQuotesInsertedSelection: Biblické citace vloženy pro výběr
+  bibleQuoteInsertedAtCursor: Biblická citace vložena na pozici kurzoru
+  noBibleLinksFound: Nebyly nalezeny žádné JW Library odkazy
+  noBibleLinkAtCursor: Na pozici kurzoru nebyl nalezen žádný JW Library odkaz
+  bibleQuoteAlreadyExists: Biblická citace již existuje
+  errorInsertingQuotes: Chyba při vkládání biblických citací
+suggestions:
+  createLink: 'Vytvořit odkaz: {{text}}'
+  createLinks: 'Vytvořit odkazy: {{text}}'
+  createAndOpen: 'Vytvořit odkaz a otevřít: {{text}}'
+  createMultipleAndOpenFirst: 'Vytvořit odkazy a otevřít první: {{text}}'
+  typing: 'Zadejte biblickou referenci: {{text}}'
+  typingEmpty: Zadejte biblickou referenci
+errors:
+  invalidVerseNumber: Neplatné číslo verše
+  versesAscendingOrder: Verše musí být ve vzestupném pořadí
+  chaptersAscendingOrder: Kapitoly musí být ve vzestupném pořadí
+  invalidVerseFormat: Neplatný formát verše
+  invalidReferenceFormat: Neplatný formát reference
+  unsupportedLanguage: Nepodporovaný jazyk

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An Obsidian plugin that helps creating JW Library links",
   "main": "main.js",
   "scripts": {
-    "dev": "DEBUG=true node esbuild.config.mjs",
+    "dev": "cross-env DEBUG=true node esbuild.config.mjs",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "version": "changeset version && node version-bump.mjs",
     "release": "VERSION=$(jq -r '.version' manifest.json) && git tag -a $VERSION -m \"Release $VERSION\" && git push origin $VERSION",
@@ -33,6 +33,7 @@
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",
     "builtin-modules": "^5.0.0",
+    "cross-env": "^10.1.0",
     "esbuild": "^0.27.4",
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       builtin-modules:
         specifier: ^5.0.0
         version: 5.0.0
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       esbuild:
         specifier: ^0.27.4
         version: 0.27.4
@@ -365,6 +368,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -1261,6 +1267,11 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2986,6 +2997,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
@@ -3899,6 +3912,11 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   crelt@1.0.6: {}
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/src/JWLibraryLinkerSettings.ts
+++ b/src/JWLibraryLinkerSettings.ts
@@ -138,6 +138,7 @@ export class JWLibraryLinkerSettings extends PluginSettingTab {
             F: 'Français',
             CR: 'Hrvatski',
             VT: 'Việt',
+            B: 'Čeština',
           } satisfies Record<Language, string>)
           .setValue(this.plugin.settings.language)
           .onChange(async (value) => {

--- a/src/__tests__/__helpers__/initializeBibleBooksForTests.ts
+++ b/src/__tests__/__helpers__/initializeBibleBooksForTests.ts
@@ -12,7 +12,7 @@ const LOCALE_DIR = join(PROJECT_ROOT, 'locale');
  * @param languages Languages to pre-load (defaults to common test languages)
  */
 export function initializeTestBibleBooks(
-  languages: Language[] = ['E', 'X', 'FI', 'O', 'S', 'F', 'KO', 'TPO', 'CR'],
+  languages: Language[] = ['E', 'X', 'FI', 'O', 'S', 'F', 'KO', 'TPO', 'CR', 'VT', 'B'],
 ): void {
   const booksCache = __getCache();
 

--- a/src/services/TranslationService.ts
+++ b/src/services/TranslationService.ts
@@ -202,7 +202,8 @@ export class TranslationService {
       locale === 'pt' ||
       locale === 'fr' ||
       locale === 'hr' ||
-      locale === 'vi'
+      locale === 'vi' ||
+      locale === 'cs'
     );
   }
 }

--- a/src/services/TranslationService.ts
+++ b/src/services/TranslationService.ts
@@ -177,16 +177,22 @@ export class TranslationService {
 
   private detectObsidianLocale(): Locale {
     try {
-      // Only try to access localStorage in a browser environment
-      if (typeof window !== 'undefined' && window.localStorage) {
-        const obsidianLocale = window.localStorage.getItem('language');
-        if (this.isValidLocale(obsidianLocale)) {
-          return obsidianLocale as Locale;
+      if (typeof window !== 'undefined') {
+        // Obsidian sets the locale via moment.js
+        const momentLocale = (
+          window as Window & { moment?: { locale: () => string } }
+        ).moment?.locale();
+        if (this.isValidLocale(momentLocale ?? null)) {
+          return momentLocale as Locale;
+        }
+        // Fallback: some older versions stored it in localStorage
+        const storageLocale = window.localStorage?.getItem('language');
+        if (this.isValidLocale(storageLocale)) {
+          return storageLocale as Locale;
         }
       }
     } catch (error) {
-      // Fallback to default 'en' if localStorage is not available
-      logger.info('Could not access localStorage, using default locale', error);
+      logger.info('Could not detect locale, using default locale', error);
     }
     return 'en';
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-export type Locale = 'en' | 'de' | 'fi' | 'es' | 'nl' | 'ko' | 'fr' | 'pt' | 'hr' | 'vi'; // obsidian language
+export type Locale = 'en' | 'de' | 'fi' | 'es' | 'nl' | 'ko' | 'fr' | 'pt' | 'hr' | 'vi' | 'cs'; // obsidian language
 
-export type Language = 'E' | 'X' | 'FI' | 'S' | 'O' | 'KO' | 'F' | 'TPO' | 'CR' | 'VT'; // plugin language
+export type Language = 'E' | 'X' | 'FI' | 'S' | 'O' | 'KO' | 'F' | 'TPO' | 'CR' | 'VT' | 'B'; // plugin language
 
 export type BookLength = 'short' | 'medium' | 'long';
 


### PR DESCRIPTION
Hi,

- Czech language support — adds full Czech (cs/B) support including all 66 Bible book     
  names with official JW abbreviations and complete UI translations
- Fix pnpm dev on Windows — adds cross-env to handle inline DEBUG=true environment        
  variable, which is not supported on Windows CMD/PowerShell
- Fix locale bundle paths on Windows — esbuild YAML plugin was using backslash path       
  separators as bundle keys on Windows, causing the plugin to fail with "English locale not 
  found in bundle"
- Fix Obsidian locale detection — detectObsidianLocale() was reading from
  localStorage.language which Obsidian does not use; fixed to use window.moment.locale()    
  instead, with localStorage as a fallback