### PR TITLE
fix: resolve Bible quote insertion issues and improve error handling

### DIFF
--- a/.changeset/fix-bible-quote-cursor-detection.md
+++ b/.changeset/fix-bible-quote-cursor-detection.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+Fix Bible quote insertion failing with `ERR_HTTP2_PROTOCOL_ERROR`. `BibleTextFetcher` now sends browser-like headers (including `Connection: keep-alive`) with `requestUrl`, which prevents Electron from upgrading to HTTP/2 for jw.org requests. Also fixes shared regex state in `findJWLibraryLinksInLine` that could cause "No JW Library link found" errors immediately after link insertion. Fixes debug logging never appearing in dev builds — the `DEBUG` flag in `esbuild.config.mjs` was not wrapped in `JSON.stringify`, so it was emitted as a boolean instead of the string `'true'` that the logger checks against.

--- a/.changeset/fix-bible-quote-cursor-detection.md
+++ b/.changeset/fix-bible-quote-cursor-detection.md
@@ -3,3 +3,7 @@
 ---
 
 Fix Bible quote insertion failing with `ERR_HTTP2_PROTOCOL_ERROR`. `BibleTextFetcher` now sends browser-like headers (including `Connection: keep-alive`) with `requestUrl`, which prevents Electron from upgrading to HTTP/2 for jw.org requests. Also fixes shared regex state in `findJWLibraryLinksInLine` that could cause "No JW Library link found" errors immediately after link insertion. Fixes debug logging never appearing in dev builds — the `DEBUG` flag in `esbuild.config.mjs` was not wrapped in `JSON.stringify`, so it was emitted as a boolean instead of the string `'true'` that the logger checks against.
+
+`BibleTextFetcher` now fetches at chapter level and caches the HTML for 5 minutes, so multiple verses from the same chapter (e.g. Matt 5:3, Matt 5:7, Matt 5:12 in one document) result in a single HTTP request. Consecutive requests to different chapters are throttled to at most one every 800 ms to avoid triggering jw.org rate limiting — this applies globally across both batch ("Insert all") and individual cursor-based insertions.
+
+Fixes plugin failing to load on builds produced on Windows (`nepodařilo se načíst plugin`) — the YAML locale bundle used OS-native backslash path separators as keys, which never matched the forward-slash lookups in `TranslationService`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,15 +17,40 @@ pnpm dev
 
 ## Testing the Plugin Locally in Obsidian
 
-1. Start dev mode with `pnpm dev`
-2. Symlink the project directory into your Obsidian vault's plugins folder:
+There are two ways to get the dev build into your vault. Pick whichever suits your OS.
 
-   ```bash
-   ln -s /path/to/jw-library-linker /path/to/your/vault/.obsidian/plugins/jw-library-linker
-   ```
+### Option A — `OBSIDIAN_PLUGIN_DIR` (recommended on Windows)
 
-3. In Obsidian, go to **Settings > Community Plugins** and enable **JW Library Linker**
-4. After making code changes, run the Obsidian command **"Reload app without saving"** to pick up the new build
+Set the `OBSIDIAN_PLUGIN_DIR` environment variable to the plugin folder inside your vault. The dev build will write `main.js` directly there on every change.
+
+**Windows (Command Prompt / PowerShell — set once per session):**
+
+```cmd
+set OBSIDIAN_PLUGIN_DIR=C:\Users\YourName\Documents\MyVault\.obsidian\plugins\jw-library-linker
+pnpm dev
+```
+
+**macOS / Linux:**
+
+```bash
+OBSIDIAN_PLUGIN_DIR="/path/to/your/vault/.obsidian/plugins/jw-library-linker" pnpm dev
+```
+
+> **Tip:** Copy the `manifest.json` and `styles.css` files into that folder once. After that, only `main.js` is updated on each rebuild.
+
+### Option B — Symlink (macOS / Linux)
+
+```bash
+ln -s /path/to/jw-library-linker /path/to/your/vault/.obsidian/plugins/jw-library-linker
+pnpm dev
+```
+
+---
+
+After either setup:
+
+1. In Obsidian, go to **Settings > Community Plugins** and enable **JW Library Linker**
+2. After making code changes, run the Obsidian command **"Reload app without saving"** to pick up the new build
 
 ## Available Scripts
 

--- a/esbuild-yaml-plugin.mjs
+++ b/esbuild-yaml-plugin.mjs
@@ -52,7 +52,7 @@ export function yamlPlugin() {
           const fullPath = path.resolve(__dirname, file);
           const yamlContent = fs.readFileSync(fullPath, 'utf8');
           const parsed = yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA });
-          locales[file] = parsed;
+          locales[file.replace(/\\/g, '/')] = parsed;
         }
 
         // Return as ES module

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -18,7 +18,7 @@ const context = await esbuild.context({
   entryPoints: ['src/main.ts'],
   bundle: true,
   define: {
-    DEBUG: process.env.DEBUG || 'false',
+    DEBUG: JSON.stringify(process.env.DEBUG || 'false'),
   },
   plugins: [yamlPlugin()],
   external: [
@@ -42,7 +42,11 @@ const context = await esbuild.context({
   logLevel: 'info',
   sourcemap: prod ? false : 'inline',
   treeShaking: true,
-  outfile: 'main.js',
+  outfile: prod
+    ? 'main.js'
+    : process.env.OBSIDIAN_PLUGIN_DIR
+      ? `${process.env.OBSIDIAN_PLUGIN_DIR}/main.js`
+      : 'main.js',
   minify: prod,
 });
 

--- a/src/__tests__/BibleTextFetcher.test.ts
+++ b/src/__tests__/BibleTextFetcher.test.ts
@@ -15,6 +15,7 @@ describe('BibleTextFetcher', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedRequestUrl.mockReset();
+    BibleTextFetcher.clearCache();
   });
 
   describe('fetchBibleText', () => {
@@ -209,6 +210,152 @@ describe('BibleTextFetcher', () => {
         expect(result.text).not.toContain('xrefLink');
         expect(result.text).not.toContain('footnoteLink');
       });
+    });
+  });
+
+  describe('chapter-level caching', () => {
+    test('makes only one HTTP request for two verses in the same chapter', async () => {
+      const chapterHtml = `
+        <div id="bibleText">
+          <span class="verse" id="v43003016"><span class="chapterNum"><a>16 </a></span> For God loved the world so much</span>
+          <span class="verse" id="v43003017"><sup class="verseNum"><a>17 </a></sup> For God did not send his Son</span>
+        </div>
+      `;
+      mockedRequestUrl.mockResolvedValue({ status: 200, text: chapterHtml });
+
+      const r1 = await BibleTextFetcher.fetchBibleText(
+        { book: 43, chapter: 3, verseRanges: [{ start: 16, end: 16 }] },
+        'E',
+      );
+      const r2 = await BibleTextFetcher.fetchBibleText(
+        { book: 43, chapter: 3, verseRanges: [{ start: 17, end: 17 }] },
+        'E',
+      );
+
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+      expect(r1.success).toBe(true);
+      expect(r2.success).toBe(true);
+      expect(r1.text).toContain('For God loved the world so much');
+      expect(r2.text).toContain('For God did not send his Son');
+    });
+
+    test('fetches separately for different chapters', async () => {
+      const html1 = `<span class="verse" id="v43003016"><span class="chapterNum">16 </span>For God loved the world</span>`;
+      const html2 = `<span class="verse" id="v43004006"><span class="chapterNum">6 </span>Jesus said to her</span>`;
+      mockedRequestUrl
+        .mockResolvedValueOnce({ status: 200, text: html1 })
+        .mockResolvedValueOnce({ status: 200, text: html2 });
+
+      await BibleTextFetcher.fetchBibleText(
+        { book: 43, chapter: 3, verseRanges: [{ start: 16, end: 16 }] },
+        'E',
+      );
+      await BibleTextFetcher.fetchBibleText(
+        { book: 43, chapter: 4, verseRanges: [{ start: 6, end: 6 }] },
+        'E',
+      );
+
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
+    });
+
+    test('fetches separately for the same chapter in different languages', async () => {
+      const htmlE = `<span class="verse" id="v43003016"><span class="chapterNum">16 </span>For God loved the world</span>`;
+      const htmlX = `<span class="verse" id="v43003016"><span class="chapterNum">16 </span>Denn Gott hat die Welt so sehr geliebt</span>`;
+      mockedRequestUrl
+        .mockResolvedValueOnce({ status: 200, text: htmlE })
+        .mockResolvedValueOnce({ status: 200, text: htmlX });
+
+      await BibleTextFetcher.fetchBibleText(
+        { book: 43, chapter: 3, verseRanges: [{ start: 16, end: 16 }] },
+        'E',
+      );
+      await BibleTextFetcher.fetchBibleText(
+        { book: 43, chapter: 3, verseRanges: [{ start: 16, end: 16 }] },
+        'X',
+      );
+
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
+    });
+
+    test('always fetches chapter at verse 001 regardless of requested verse', async () => {
+      const html = `<span class="verse" id="v43003016"><span class="chapterNum">16 </span>For God loved the world</span>`;
+      mockedRequestUrl.mockResolvedValue({ status: 200, text: html });
+
+      await BibleTextFetcher.fetchBibleText(
+        { book: 43, chapter: 3, verseRanges: [{ start: 16, end: 16 }] },
+        'E',
+      );
+
+      const [[callArg]] = mockedRequestUrl.mock.calls as [[{ url: string }]];
+      expect(callArg.url).toContain('43003001');
+    });
+  });
+
+  describe('request throttling', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test('throttles consecutive requests for different chapters', async () => {
+      const html1 = `<span class="verse" id="v43003016"><span class="chapterNum">16 </span>For God loved the world</span>`;
+      const html2 = `<span class="verse" id="v43004006"><span class="chapterNum">6 </span>Jesus said to her</span>`;
+      mockedRequestUrl
+        .mockResolvedValueOnce({ status: 200, text: html1 })
+        .mockResolvedValueOnce({ status: 200, text: html2 });
+
+      // First request — no previous request, no throttle wait
+      const p1 = BibleTextFetcher.fetchBibleText(
+        { book: 43, chapter: 3, verseRanges: [{ start: 16, end: 16 }] },
+        'E',
+      );
+      await jest.runAllTimersAsync();
+      const r1 = await p1;
+      expect(r1.success).toBe(true);
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+
+      // Second request immediately after — throttle delay kicks in before the HTTP request
+      const p2 = BibleTextFetcher.fetchBibleText(
+        { book: 43, chapter: 4, verseRanges: [{ start: 6, end: 6 }] },
+        'E',
+      );
+      // Before timers run, the second HTTP request has not been made yet
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+
+      await jest.runAllTimersAsync();
+      const r2 = await p2;
+      expect(r2.success).toBe(true);
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not throttle cache hits', async () => {
+      const chapterHtml = `
+        <span class="verse" id="v43003016"><span class="chapterNum">16 </span>For God loved the world</span>
+        <span class="verse" id="v43003017"><sup class="verseNum">17 </sup>For God did not send his Son</span>
+      `;
+      mockedRequestUrl.mockResolvedValue({ status: 200, text: chapterHtml });
+
+      // First request fetches and caches the chapter
+      const p1 = BibleTextFetcher.fetchBibleText(
+        { book: 43, chapter: 3, verseRanges: [{ start: 16, end: 16 }] },
+        'E',
+      );
+      await jest.runAllTimersAsync();
+      await p1;
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+
+      // Second request for same chapter — cache hit, resolves without running any timers
+      const p2 = BibleTextFetcher.fetchBibleText(
+        { book: 43, chapter: 3, verseRanges: [{ start: 17, end: 17 }] },
+        'E',
+      );
+      const r2 = await p2;
+
+      expect(r2.success).toBe(true);
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(1); // Still only 1 HTTP request
     });
   });
 });

--- a/src/__tests__/BibleTextFetcher.test.ts
+++ b/src/__tests__/BibleTextFetcher.test.ts
@@ -1,3 +1,5 @@
+// @jest-environment jsdom
+
 // Unmock BibleTextFetcher in case other tests mocked it
 jest.unmock('@/services/BibleTextFetcher');
 
@@ -12,7 +14,6 @@ const mockedRequestUrl = requestUrl as jest.Mock;
 describe('BibleTextFetcher', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Reset mock implementation
     mockedRequestUrl.mockReset();
   });
 
@@ -27,10 +28,7 @@ describe('BibleTextFetcher', () => {
           </div>
         `;
 
-        mockedRequestUrl.mockResolvedValue({
-          status: 200,
-          text: html,
-        });
+        mockedRequestUrl.mockResolvedValue({ status: 200, text: html });
 
         const result = await BibleTextFetcher.fetchBibleText(
           {
@@ -57,10 +55,7 @@ describe('BibleTextFetcher', () => {
           </div>
         `;
 
-        mockedRequestUrl.mockResolvedValue({
-          status: 200,
-          text: html,
-        });
+        mockedRequestUrl.mockResolvedValue({ status: 200, text: html });
 
         const result = await BibleTextFetcher.fetchBibleText(
           {
@@ -86,10 +81,7 @@ describe('BibleTextFetcher', () => {
           </div>
         `;
 
-        mockedRequestUrl.mockResolvedValue({
-          status: 200,
-          text: html,
-        });
+        mockedRequestUrl.mockResolvedValue({ status: 200, text: html });
 
         const result = await BibleTextFetcher.fetchBibleText(
           {
@@ -113,10 +105,7 @@ describe('BibleTextFetcher', () => {
           </div>
         `;
 
-        mockedRequestUrl.mockResolvedValue({
-          status: 200,
-          text: html,
-        });
+        mockedRequestUrl.mockResolvedValue({ status: 200, text: html });
 
         const result = await BibleTextFetcher.fetchBibleText(
           {
@@ -144,10 +133,7 @@ describe('BibleTextFetcher', () => {
           </div>
         `;
 
-        mockedRequestUrl.mockResolvedValue({
-          status: 200,
-          text: html,
-        });
+        mockedRequestUrl.mockResolvedValue({ status: 200, text: html });
 
         const result = await BibleTextFetcher.fetchBibleText(
           {
@@ -177,10 +163,7 @@ describe('BibleTextFetcher', () => {
           </div>
         `;
 
-        mockedRequestUrl.mockResolvedValue({
-          status: 200,
-          text: html,
-        });
+        mockedRequestUrl.mockResolvedValue({ status: 200, text: html });
 
         const result = await BibleTextFetcher.fetchBibleText(
           {
@@ -208,10 +191,7 @@ describe('BibleTextFetcher', () => {
           </div>
         `;
 
-        mockedRequestUrl.mockResolvedValue({
-          status: 200,
-          text: html,
-        });
+        mockedRequestUrl.mockResolvedValue({ status: 200, text: html });
 
         const result = await BibleTextFetcher.fetchBibleText(
           {

--- a/src/__tests__/__mocks__/electron.ts
+++ b/src/__tests__/__mocks__/electron.ts
@@ -1,0 +1,3 @@
+export const net = {
+  fetch: jest.fn(),
+};

--- a/src/__tests__/insertBibleQuotes.test.ts
+++ b/src/__tests__/insertBibleQuotes.test.ts
@@ -339,6 +339,35 @@ describe('insertBibleQuoteAtCursor', () => {
     });
   });
 
+  test('should insert quote when cursor is on the same line as a markdown link', async () => {
+    const linkLine = '[Mat 24:14](jwlibrary:///finder?bible=40024014&wtlocale=E)';
+    mockGetCursor.mockReturnValue({ line: 0, ch: linkLine.length });
+    mockLastLine.mockReturnValue(0);
+    mockGetLine.mockReturnValue(linkLine);
+
+    (BibleTextFetcher.fetchBibleText as jest.Mock).mockResolvedValueOnce({
+      success: true,
+      text: 'And this good news of the Kingdom will be preached in all the inhabited earth.',
+    });
+
+    (convertBibleTextToMarkdownLink as jest.Mock).mockReturnValueOnce(linkLine);
+
+    const result = await insertBibleQuoteAtCursor(mockEditor, settings);
+
+    expect(result).toEqual({ inserted: true, alreadyExists: false });
+    expect(mockTransaction).toHaveBeenCalledWith({
+      changes: [
+        {
+          from: { line: 0, ch: 0 },
+          to: { line: 0, ch: linkLine.length },
+          text:
+            '[Mat 24:14](jwlibrary:///finder?bible=40024014&wtlocale=E)\n' +
+            '> And this good news of the Kingdom will be preached in all the inhabited earth.',
+        },
+      ],
+    });
+  });
+
   test('should detect existing quote', async () => {
     mockGetCursor.mockReturnValue({ line: 0, ch: 10 });
     mockLastLine.mockReturnValue(1);

--- a/src/main.ts
+++ b/src/main.ts
@@ -190,6 +190,8 @@ export default class JWLibraryLinkerPlugin extends Plugin {
             new Notice(this.t('notices.bibleQuoteInsertedAtCursor'));
           } else if (result.alreadyExists) {
             new Notice(this.t('notices.bibleQuoteAlreadyExists'));
+          } else if (result.fetchFailed) {
+            new Notice(this.t('notices.errorInsertingQuotes'));
           } else {
             new Notice(this.t('notices.noBibleLinkAtCursor'));
           }
@@ -226,6 +228,8 @@ export default class JWLibraryLinkerPlugin extends Plugin {
                     new Notice(this.t('notices.bibleQuoteInsertedAtCursor'));
                   } else if (result.alreadyExists) {
                     new Notice(this.t('notices.bibleQuoteAlreadyExists'));
+                  } else if (result.fetchFailed) {
+                    new Notice(this.t('notices.errorInsertingQuotes'));
                   } else {
                     new Notice(this.t('notices.noBibleLinkAtCursor'));
                   }

--- a/src/services/BibleTextFetcher.ts
+++ b/src/services/BibleTextFetcher.ts
@@ -48,13 +48,21 @@ export class BibleTextFetcher {
 
       logger.log('url', url);
 
-      // Fetch the content using Obsidian's requestUrl (no CORS restrictions in Electron)
-      const response = await requestUrl({ url });
-
-      logger.log('response', response);
+      const response = await requestUrl({
+        url,
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+          'Accept-Language': 'en-US,en;q=0.5',
+          DNT: '1',
+          Connection: 'keep-alive',
+          'Upgrade-Insecure-Requests': '1',
+        },
+      });
 
       if (response.status !== 200) {
-        throw new Error(`HTTP ${response.status}: ${response.status}`);
+        throw new Error(`HTTP ${response.status}`);
       }
 
       const html = response.text;

--- a/src/services/BibleTextFetcher.ts
+++ b/src/services/BibleTextFetcher.ts
@@ -14,6 +14,91 @@ export interface BibleTextResult {
 export class BibleTextFetcher {
   private static readonly JW_ORG_BASE = 'https://www.jw.org/finder?bible=';
   private static readonly WOL_BASE = 'https://wol.jw.org/en/wol/b/r1/lp-e/';
+  private static readonly MIN_REQUEST_INTERVAL_MS = 800;
+  private static readonly CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+  private static lastRequestTime = -Infinity;
+  private static readonly chapterHtmlCache = new Map<string, { html: string; timestamp: number }>();
+
+  /** Clears the chapter HTML cache and resets the throttle timer. */
+  static clearCache(): void {
+    this.chapterHtmlCache.clear();
+    this.lastRequestTime = -Infinity;
+  }
+
+  private static async throttleRequest(): Promise<void> {
+    const wait = this.MIN_REQUEST_INTERVAL_MS - (Date.now() - this.lastRequestTime);
+    if (wait > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, wait));
+    }
+    this.lastRequestTime = Date.now();
+  }
+
+  private static getCachedHtml(cacheKey: string): string | null {
+    const entry = this.chapterHtmlCache.get(cacheKey);
+    if (!entry) return null;
+    if (Date.now() - entry.timestamp > this.CACHE_TTL_MS) {
+      this.chapterHtmlCache.delete(cacheKey);
+      return null;
+    }
+    return entry.html;
+  }
+
+  /**
+   * Fetches the full chapter HTML, using a cache to avoid redundant requests.
+   * Always requests verse 001 as the entry point — jw.org returns the full chapter HTML
+   * regardless of which verse is requested. Throttles real HTTP requests to at most one
+   * every 800 ms to avoid triggering jw.org rate limiting.
+   */
+  private static async fetchChapterHtml(
+    book: number,
+    chapter: number,
+    language: Language,
+    useWOL: boolean,
+  ): Promise<string> {
+    const paddedBook = padBook(book);
+    const paddedChapter = padChapter(chapter);
+    const cacheKey = `${useWOL ? 'wol' : 'jw'}:${language}:${paddedBook}${paddedChapter}`;
+
+    const cached = this.getCachedHtml(cacheKey);
+    if (cached) {
+      logger.log('chapter cache hit', cacheKey);
+      return cached;
+    }
+
+    await this.throttleRequest();
+
+    // Re-check after the throttle wait — a concurrent request may have fetched and cached it
+    const cachedAfterWait = this.getCachedHtml(cacheKey);
+    if (cachedAfterWait) return cachedAfterWait;
+
+    const chapterCode = `${paddedBook}${paddedChapter}001`;
+    const url = useWOL
+      ? this.buildWOLUrl(chapterCode, language)
+      : this.buildJWOrgUrl(chapterCode, language);
+
+    logger.log('fetching chapter', url);
+
+    const response = await requestUrl({
+      url,
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+        DNT: '1',
+        Connection: 'keep-alive',
+        'Upgrade-Insecure-Requests': '1',
+      },
+    });
+
+    if (response.status !== 200) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    this.chapterHtmlCache.set(cacheKey, { html: response.text, timestamp: Date.now() });
+    return response.text;
+  }
 
   static async fetchBibleText(
     reference: BibleReference,
@@ -33,39 +118,7 @@ export class BibleTextFetcher {
         };
       }
 
-      // Format the Bible reference for the URL
-      const bibleCode = this.formatBibleCode(
-        book,
-        chapter,
-        verseRanges[0].start,
-        verseRanges[0].end,
-      );
-
-      // Choose the appropriate URL based on preference
-      const url = useWOL
-        ? this.buildWOLUrl(bibleCode, language)
-        : this.buildJWOrgUrl(bibleCode, language);
-
-      logger.log('url', url);
-
-      const response = await requestUrl({
-        url,
-        headers: {
-          'User-Agent':
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
-          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-          'Accept-Language': 'en-US,en;q=0.5',
-          DNT: '1',
-          Connection: 'keep-alive',
-          'Upgrade-Insecure-Requests': '1',
-        },
-      });
-
-      if (response.status !== 200) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-
-      const html = response.text;
+      const html = await this.fetchChapterHtml(book, chapter, language, useWOL);
       const result = this.extractBibleText(html, reference);
 
       return {
@@ -80,24 +133,6 @@ export class BibleTextFetcher {
         error: error instanceof Error ? error.message : 'Unknown error occurred',
       };
     }
-  }
-
-  private static formatBibleCode(
-    book: number,
-    chapter: number,
-    startVerse: number,
-    endVerse?: number,
-  ): string {
-    const paddedBook = padBook(book);
-    const paddedChapter = padChapter(chapter);
-    const paddedStart = padVerse(startVerse);
-
-    if (endVerse && endVerse !== startVerse) {
-      const paddedEnd = padVerse(endVerse);
-      return `${paddedBook}${paddedChapter}${paddedStart}-${paddedBook}${paddedChapter}${paddedEnd}`;
-    }
-
-    return `${paddedBook}${paddedChapter}${paddedStart}`;
   }
 
   private static buildJWOrgUrl(bibleCode: string, language: Language): string {

--- a/src/utils/findJWLibraryLinks.ts
+++ b/src/utils/findJWLibraryLinks.ts
@@ -15,8 +15,6 @@ export interface ContentSelection {
   endLine: number;
 }
 
-const JW_LIBRARY_LINK_REGEX = /jwlibrary:\/\/\/finder\?bible=\d{8}(?:-\d{8})?(?:&[^)\s]*)?/g;
-
 function parseSingleBibleCode(code: string): BibleReference | null {
   if (code.length !== 8) return null;
 
@@ -83,7 +81,8 @@ export function findJWLibraryLinks(
 
 export function findJWLibraryLinksInLine(line: string, lineNumber: number): JWLibraryLinkInfo[] {
   const links: JWLibraryLinkInfo[] = [];
-  const matches = Array.from(line.matchAll(JW_LIBRARY_LINK_REGEX));
+  const jwLibraryRegex = /jwlibrary:\/\/\/finder\?bible=\d{8}(?:-\d{8})?(?:&[^)\s]*)?/g;
+  const matches = Array.from(line.matchAll(jwLibraryRegex));
 
   for (const match of matches) {
     logger.log('match', match);

--- a/src/utils/insertBibleQuotes.ts
+++ b/src/utils/insertBibleQuotes.ts
@@ -41,6 +41,7 @@ async function generateBibleQuoteText(
     );
 
     if (!result.success || !result.text) {
+      logger.warn('Bible text fetch failed:', result.error ?? 'unknown error');
       return null;
     }
 
@@ -59,7 +60,7 @@ async function generateBibleQuoteText(
 
     return processed;
   } catch (error: unknown) {
-    console.error(
+    logger.error(
       'Error generating Bible quote:',
       error instanceof Error ? error.message : String(error),
     );
@@ -138,7 +139,7 @@ export async function insertBibleQuoteAtCursor(
   editor: Editor,
   settings: LinkReplacerSettings,
   useWOL = false,
-): Promise<{ inserted: boolean; alreadyExists: boolean }> {
+): Promise<{ inserted: boolean; alreadyExists: boolean; fetchFailed?: boolean }> {
   const cursor = editor.getCursor();
   const cursorLine = cursor.line;
 
@@ -183,6 +184,11 @@ export async function insertBibleQuoteAtCursor(
   }
 
   if (linksOnTargetLine.length === 0) {
+    logger.warn(
+      'insertBibleQuoteAtCursor: no JW Library link found near cursor (line',
+      cursorLine,
+      ')',
+    );
     return { inserted: false, alreadyExists: false };
   }
 
@@ -219,5 +225,9 @@ export async function insertBibleQuoteAtCursor(
     return { inserted: true, alreadyExists: false };
   }
 
-  return { inserted: false, alreadyExists: false };
+  logger.warn(
+    'insertBibleQuoteAtCursor: link found but Bible text fetch failed for',
+    linksOnTargetLine.map((l) => l.url),
+  );
+  return { inserted: false, alreadyExists: false, fetchFailed: true };
 }

--- a/src/utils/linkUnlinkedBibleReferences.ts
+++ b/src/utils/linkUnlinkedBibleReferences.ts
@@ -27,6 +27,7 @@ export function linkUnlinkedBibleReferences(
   // Scan each line for Bible references using the findBibleReferenceRegex
   lines.forEach((line, lineIndex) => {
     let match;
+    BIBLE_REFERENCE_REGEX.lastIndex = 0;
     while ((match = BIBLE_REFERENCE_REGEX.exec(line)) !== null) {
       // check if match is already a link
       if (line.includes(`[${match[0]}]`)) {


### PR DESCRIPTION
- Bible quote insertion broken (closes #239) — BibleTextFetcher was calling requestUrl without headers, causing Electron to use HTTP/2. jw.org returned ERR_HTTP2_PROTOCOL_ERROR. Fix: pass        
  browser-like headers including Connection: keep-alive to stay on HTTP/1.1.
- Debug logging never worked in dev builds — DEBUG flag in esbuild.config.mjs was missing
  JSON.stringify, emitting a boolean instead of the string 'true' the logger checks against.
- Shared regex state causing missed links — JW_LIBRARY_LINK_REGEX was module-level with the g flag; 
  its lastIndex persisted between calls. Fixed by creating the regex per call. Same bug fixed in      
  linkUnlinkedBibleReferences.ts with an explicit lastIndex = 0 reset.
- Dev: OBSIDIAN_PLUGIN_DIR support — set this env variable to your vault's plugin folder and pnpm   
  dev will write main.js directly there on every rebuild, no symlink needed. Documented in
  DEVELOPMENT.md.