### PR TITLE
fix: support Bible book names with spaces, hyphens, and digits (Korean/Vietnamese)

### DIFF
--- a/.changeset/bypass-regex-gate-explicit-mode.md
+++ b/.changeset/bypass-regex-gate-explicit-mode.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+Bypass regex gate in explicit /b mode so non-Latin book names (Korean, Vietnamese, etc.) can be parsed directly by parseBibleReference.

--- a/.changeset/bypass-regex-gate-explicit-mode.md
+++ b/.changeset/bypass-regex-gate-explicit-mode.md
@@ -1,5 +1,0 @@
----
-'jw-library-linker': patch
----
-
-Bypass regex gate in explicit /b mode so non-Latin book names (Korean, Vietnamese, etc.) can be parsed directly by parseBibleReference.

--- a/.changeset/korean-vietnamese-matching.md
+++ b/.changeset/korean-vietnamese-matching.md
@@ -1,0 +1,10 @@
+---
+'jw-library-linker': minor
+---
+
+Improve Bible book name matching for Korean, Vietnamese, and other languages with spaces, hyphens, or embedded digits in book names.
+
+- Explicit `/b` mode now matches all book name formats directly without regex pre-filtering
+- Bulk convert uses data-driven regex built from actual book names for accurate detection
+- Silent mode now supports hyphenated book names (e.g., Vietnamese Lê-vi, Ru-tơ)
+- Book name normalization now strips hyphens for consistent matching

--- a/src/BibleReferenceSuggester.ts
+++ b/src/BibleReferenceSuggester.ts
@@ -114,18 +114,13 @@ export class BibleReferenceSuggester extends EditorSuggest<BibleSuggestion> {
       ];
     }
 
-    if (!query.match(BIBLE_REFERENCE_REGEX)) {
-      if (!isExplicitMode) return [];
-      return [
-        {
-          text: query,
-          command: 'typing',
-          description: this.t('suggestions.typing', { text: query }),
-        },
-      ];
+    // Silent mode: use generic regex to avoid false positives
+    if (!isExplicitMode && !query.match(BIBLE_REFERENCE_REGEX)) {
+      return [];
     }
 
-    // If it's a complete reference, parse and show detailed suggestions
+    // Try parsing the reference directly — this handles all book name formats
+    // including multi-word, hyphenated, and digit-suffixed names
     let reference: BibleReference | null = null;
 
     try {

--- a/src/__tests__/__helpers__/initializeBibleBooksForTests.ts
+++ b/src/__tests__/__helpers__/initializeBibleBooksForTests.ts
@@ -12,7 +12,7 @@ const LOCALE_DIR = join(PROJECT_ROOT, 'locale');
  * @param languages Languages to pre-load (defaults to common test languages)
  */
 export function initializeTestBibleBooks(
-  languages: Language[] = ['E', 'X', 'FI', 'O', 'S', 'F', 'KO', 'TPO', 'CR'],
+  languages: Language[] = ['E', 'X', 'FI', 'O', 'S', 'F', 'KO', 'TPO', 'CR', 'VT'],
 ): void {
   const booksCache = __getCache();
 

--- a/src/__tests__/bibleReferenceRegex.test.ts
+++ b/src/__tests__/bibleReferenceRegex.test.ts
@@ -86,6 +86,8 @@ describe('Bible Reference Regex Pattern', () => {
     '1 Sa-mu-ên 1:1',
     '1 Phi-e-rơ 1:1',
     '2 Phi-e-rơ 1:1',
+    'Giô-suê 1:1',
+    'Mi-chê 1:1',
   ];
 
   const validSpanishReferences = [
@@ -99,14 +101,6 @@ describe('Bible Reference Regex Pattern', () => {
     'Nehemías 1:1',
     'Eclesiastés 1:1',
     'Isaías 1:1',
-  ];
-
-  const validVietnameseReferences = [
-    'Lê-vi 25:1',
-    'Ru-tơ 1:1',
-    'Giô-suê 1:1',
-    'Ha-ba-cúc 1:1',
-    'Mi-chê 1:1',
   ];
 
   const invalidReferences = [

--- a/src/__tests__/bibleReferenceRegex.test.ts
+++ b/src/__tests__/bibleReferenceRegex.test.ts
@@ -101,6 +101,14 @@ describe('Bible Reference Regex Pattern', () => {
     'Isaías 1:1',
   ];
 
+  const validVietnameseReferences = [
+    'Lê-vi 25:1',
+    'Ru-tơ 1:1',
+    'Giô-suê 1:1',
+    'Ha-ba-cúc 1:1',
+    'Mi-chê 1:1',
+  ];
+
   const invalidReferences = [
     // Invalid formats
     'joh:1',

--- a/src/__tests__/buildBookNameRegex.test.ts
+++ b/src/__tests__/buildBookNameRegex.test.ts
@@ -1,0 +1,90 @@
+import { buildBookNameRegex } from '@/utils/buildBookNameRegex';
+import { initializeTestBibleBooks } from './__helpers__/initializeBibleBooksForTests';
+
+beforeAll(() => {
+  initializeTestBibleBooks();
+});
+
+describe('buildBookNameRegex', () => {
+  test('matches Korean short names with digits', () => {
+    const regex = buildBookNameRegex('KO');
+    expect('요1 1:1'.match(regex)).toBeTruthy();
+    expect('요2 1:1'.match(regex)).toBeTruthy();
+    expect('요3 1:1'.match(regex)).toBeTruthy();
+  });
+
+  test('matches Korean multi-word book names', () => {
+    const regex = buildBookNameRegex('KO');
+    expect('요한 1서 1:1'.match(regex)).toBeTruthy();
+    expect('요한 2서 1:1'.match(regex)).toBeTruthy();
+    expect('요한 3서 1:1'.match(regex)).toBeTruthy();
+    expect('요한 계시록 1:1'.match(regex)).toBeTruthy();
+    expect('고린도 전서 1:1'.match(regex)).toBeTruthy();
+    expect('데살로니가 전서 1:1'.match(regex)).toBeTruthy();
+  });
+
+  test('matches Korean simple book names', () => {
+    const regex = buildBookNameRegex('KO');
+    expect('창 1:1'.match(regex)).toBeTruthy();
+    expect('창세기 1:1'.match(regex)).toBeTruthy();
+    expect('요한복음 3:16'.match(regex)).toBeTruthy();
+  });
+
+  test('matches Vietnamese hyphenated book names', () => {
+    const regex = buildBookNameRegex('VT');
+    expect('Lê-vi 25:1'.match(regex)).toBeTruthy();
+    expect('Ru-tơ 1:1'.match(regex)).toBeTruthy();
+    expect('1 Sa-mu-ên 3:1'.match(regex)).toBeTruthy();
+    expect('2 Sa-mu-ên 3:1'.match(regex)).toBeTruthy();
+    expect('Giô-suê 1:1'.match(regex)).toBeTruthy();
+  });
+
+  test('matches Vietnamese multi-word book names', () => {
+    const regex = buildBookNameRegex('VT');
+    expect('Sáng thế 1:1'.match(regex)).toBeTruthy();
+    expect('Xuất Ai Cập 1:1'.match(regex)).toBeTruthy();
+    expect('Phục truyền luật lệ 1:1'.match(regex)).toBeTruthy();
+  });
+
+  test('matches Vietnamese short names', () => {
+    const regex = buildBookNameRegex('VT');
+    expect('Sa 1:1'.match(regex)).toBeTruthy();
+    expect('1Sa 3:1'.match(regex)).toBeTruthy();
+  });
+
+  test('matches English book names', () => {
+    const regex = buildBookNameRegex('E');
+    expect('John 3:16'.match(regex)).toBeTruthy();
+    expect('1 Corinthians 1:1'.match(regex)).toBeTruthy();
+    expect('Rev 21:4'.match(regex)).toBeTruthy();
+    expect('Matt. 6:33'.match(regex)).toBeTruthy();
+  });
+
+  test('matches German book names', () => {
+    const regex = buildBookNameRegex('X');
+    expect('Offenbarung 21:4'.match(regex)).toBeTruthy();
+    expect('1. Mose 1:1'.match(regex)).toBeTruthy();
+    expect('Röm 8:28'.match(regex)).toBeTruthy();
+  });
+
+  test('matches verse ranges', () => {
+    const regex = buildBookNameRegex('E');
+    expect('John 3:16-17'.match(regex)).toBeTruthy();
+    expect('John 1:1,2,4'.match(regex)).toBeTruthy();
+    expect('Matt 3:1-4:11'.match(regex)).toBeTruthy();
+  });
+
+  test('prefers longest match', () => {
+    const regex = buildBookNameRegex('KO');
+    const match = '요한 1서 1:1'.match(regex);
+    // Should match the full "요한 1서 1:1" not just "요한"
+    expect(match).toBeTruthy();
+    expect(match![0]).toContain('요한 1서');
+  });
+
+  test('does not match random text', () => {
+    const regex = buildBookNameRegex('E');
+    expect('Hello world'.match(regex)).toBeNull();
+    expect('The number 3:16 is interesting'.match(regex)).toBeNull();
+  });
+});

--- a/src/__tests__/findBook.test.ts
+++ b/src/__tests__/findBook.test.ts
@@ -81,4 +81,17 @@ describe('findBook', () => {
     expect(findBook(' gen ', 'E')).toEqual(expect.objectContaining({ id: 1 }));
     expect(findBook(' 1 moo ', 'FI')).toEqual(expect.objectContaining({ id: 1 }));
   });
+
+  test('finds Vietnamese books with hyphens stripped from query', () => {
+    expect(findBook('lêvi', 'VT')).toEqual(expect.objectContaining({ id: 3 }));
+    expect(findBook('rutơ', 'VT')).toEqual(expect.objectContaining({ id: 8 }));
+    expect(findBook('1samuên', 'VT')).toEqual(expect.objectContaining({ id: 9 }));
+    expect(findBook('giôsuê', 'VT')).toEqual(expect.objectContaining({ id: 6 }));
+  });
+
+  test('finds Vietnamese books with hyphens in query', () => {
+    expect(findBook('lê-vi', 'VT')).toEqual(expect.objectContaining({ id: 3 }));
+    expect(findBook('ru-tơ', 'VT')).toEqual(expect.objectContaining({ id: 8 }));
+    expect(findBook('1 sa-mu-ên', 'VT')).toEqual(expect.objectContaining({ id: 9 }));
+  });
 });

--- a/src/__tests__/linkUnlinkedBibleReferences.test.ts
+++ b/src/__tests__/linkUnlinkedBibleReferences.test.ts
@@ -132,6 +132,68 @@ describe('linkUnlinkedBibleReferences', () => {
     });
   });
 
+  test('should find and create links for Korean multi-word references', () => {
+    const koreanSettings: LinkReplacerSettings = {
+      ...TEST_DEFAULT_SETTINGS,
+      language: 'KO',
+    };
+
+    const koreanText = '요한 1서 1:1을 읽어보세요.';
+
+    linkUnlinkedBibleReferences(koreanText, koreanSettings, callbackMock);
+
+    const callbackArgs = callbackMock.mock.calls[0][0];
+    expect(callbackArgs.error).toBeUndefined();
+    expect(callbackArgs.changes.length).toBe(1);
+    expect(callbackArgs.changes[0].text).toContain('jwlibrary:///finder?bible=');
+  });
+
+  test('should find and create links for Korean digit-suffixed references', () => {
+    const koreanSettings: LinkReplacerSettings = {
+      ...TEST_DEFAULT_SETTINGS,
+      language: 'KO',
+    };
+
+    const koreanText = '요1 1:1을 읽어보세요.';
+
+    linkUnlinkedBibleReferences(koreanText, koreanSettings, callbackMock);
+
+    const callbackArgs = callbackMock.mock.calls[0][0];
+    expect(callbackArgs.error).toBeUndefined();
+    expect(callbackArgs.changes.length).toBe(1);
+    expect(callbackArgs.changes[0].text).toContain('jwlibrary:///finder?bible=');
+  });
+
+  test('should find and create links for Vietnamese hyphenated references', () => {
+    const vietnameseSettings: LinkReplacerSettings = {
+      ...TEST_DEFAULT_SETTINGS,
+      language: 'VT',
+    };
+
+    const vietnameseText = 'Hãy đọc Lê-vi 25:1 và Ru-tơ 1:1.';
+
+    linkUnlinkedBibleReferences(vietnameseText, vietnameseSettings, callbackMock);
+
+    const callbackArgs = callbackMock.mock.calls[0][0];
+    expect(callbackArgs.error).toBeUndefined();
+    expect(callbackArgs.changes.length).toBe(2);
+  });
+
+  test('should find and create links for Vietnamese multi-word references', () => {
+    const vietnameseSettings: LinkReplacerSettings = {
+      ...TEST_DEFAULT_SETTINGS,
+      language: 'VT',
+    };
+
+    const vietnameseText = 'Sáng thế 1:1 là câu đầu tiên.';
+
+    linkUnlinkedBibleReferences(vietnameseText, vietnameseSettings, callbackMock);
+
+    const callbackArgs = callbackMock.mock.calls[0][0];
+    expect(callbackArgs.error).toBeUndefined();
+    expect(callbackArgs.changes.length).toBe(1);
+  });
+
   test('should preserve spaces around Bible references when converting to links', () => {
     // Arrange
     const textWithSpaces = `Some text before John 3:16 and some text after.`;

--- a/src/__tests__/parseBibleReference.test.ts
+++ b/src/__tests__/parseBibleReference.test.ts
@@ -96,24 +96,32 @@ describe('parseBibleReference', () => {
         verseRanges: [{ start: 1, end: 1 }],
       },
     },
+    {
+      description: 'parses Korean multi-word book name (1 John)',
+      input: '요한 1서 1:1',
+      language: 'KO' as Language,
+      expected: {
+        book: 62,
+        chapter: 1,
+        verseRanges: [{ start: 1, end: 1 }],
+      },
+    },
+    {
+      description: 'parses Korean digit-suffixed short name (1 John)',
+      input: '요1 1:1',
+      language: 'KO' as Language,
+      expected: {
+        book: 62,
+        chapter: 1,
+        verseRanges: [{ start: 1, end: 1 }],
+      },
+    },
   ];
 
   // Run the successful parsing tests
   test.each(successTestCases)('$description', ({ input, expected, language: testLanguage }) => {
     const parseResult = parseBibleReference(input, testLanguage ?? language);
     expect(parseResult).toEqual(expected);
-  });
-
-  // Known limitation: Korean multi-word book names like "요한 1서" (1 John) are ambiguous
-  // because the extraction regex captures "요한" (John) as the book name, leaving "1서1:1"
-  // as the remainder. This will be addressed in Task 3 (Korean digit-suffixed names).
-  test.skip('parses Korean multi-word book name (1 John)', () => {
-    const parseResult = parseBibleReference('요한 1서 1:1', 'KO');
-    expect(parseResult).toEqual({
-      book: 62,
-      chapter: 1,
-      verseRanges: [{ start: 1, end: 1 }],
-    });
   });
 
   // Test cases for error handling - ascending order errors

--- a/src/__tests__/parseBibleReference.test.ts
+++ b/src/__tests__/parseBibleReference.test.ts
@@ -66,12 +66,54 @@ describe('parseBibleReference', () => {
         ],
       },
     },
+    {
+      description: 'parses Vietnamese hyphenated book name',
+      input: 'Lê-vi 25:1',
+      language: 'VT' as Language,
+      expected: {
+        book: 3,
+        chapter: 25,
+        verseRanges: [{ start: 1, end: 1 }],
+      },
+    },
+    {
+      description: 'parses Vietnamese hyphenated book name with prefix',
+      input: '1 Sa-mu-ên 3:1',
+      language: 'VT' as Language,
+      expected: {
+        book: 9,
+        chapter: 3,
+        verseRanges: [{ start: 1, end: 1 }],
+      },
+    },
+    {
+      description: 'parses Korean multi-word book name (Revelation)',
+      input: '요한 계시록 1:1',
+      language: 'KO' as Language,
+      expected: {
+        book: 66,
+        chapter: 1,
+        verseRanges: [{ start: 1, end: 1 }],
+      },
+    },
   ];
 
   // Run the successful parsing tests
-  test.each(successTestCases)('$description', ({ input, expected }) => {
-    const parseResult = parseBibleReference(input, language);
+  test.each(successTestCases)('$description', ({ input, expected, language: testLanguage }) => {
+    const parseResult = parseBibleReference(input, testLanguage ?? language);
     expect(parseResult).toEqual(expected);
+  });
+
+  // Known limitation: Korean multi-word book names like "요한 1서" (1 John) are ambiguous
+  // because the extraction regex captures "요한" (John) as the book name, leaving "1서1:1"
+  // as the remainder. This will be addressed in Task 3 (Korean digit-suffixed names).
+  test.skip('parses Korean multi-word book name (1 John)', () => {
+    const parseResult = parseBibleReference('요한 1서 1:1', 'KO');
+    expect(parseResult).toEqual({
+      book: 62,
+      chapter: 1,
+      verseRanges: [{ start: 1, end: 1 }],
+    });
   });
 
   // Test cases for error handling - ascending order errors

--- a/src/utils/buildBookNameRegex.ts
+++ b/src/utils/buildBookNameRegex.ts
@@ -1,0 +1,52 @@
+import type { Language } from '@/types';
+import { getBibleBooks } from '@/stores/bibleBooks';
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function buildBookNameRegex(language: Language): RegExp {
+  const books = getBibleBooks(language);
+
+  const allNames: string[] = [];
+
+  for (const book of books) {
+    // Collect all name variants
+    const names = [book.name.short, book.name.medium, book.name.long];
+
+    // Add aliases with prefix
+    for (const alias of book.aliases) {
+      if (book.prefix) {
+        allNames.push(`${book.prefix}${alias}`);
+        allNames.push(`${book.prefix} ${alias}`);
+        allNames.push(`${book.prefix}.${alias}`);
+        allNames.push(`${book.prefix}. ${alias}`);
+      } else {
+        allNames.push(alias);
+      }
+    }
+
+    for (const name of names) {
+      allNames.push(name);
+      // For names ending with '.', also add the variant without the dot
+      // so "Rev." also matches "Rev" and "Matt." also matches "Matt"
+      if (name.endsWith('.')) {
+        allNames.push(name.slice(0, -1));
+      }
+    }
+  }
+
+  // Deduplicate and filter empty
+  const uniqueNames = [...new Set(allNames.filter((n) => n.length > 0))];
+
+  // Sort by length descending — longest first for greedy matching
+  uniqueNames.sort((a, b) => b.length - a.length);
+
+  // Escape regex special chars and join
+  const bookPattern = uniqueNames.map(escapeRegex).join('|');
+
+  // Build full regex: book name + optional dot/space + chapter:verse pattern
+  const chapterVersePattern = '\\.?\\s?\\d+:\\d+(?:-\\d+(?::\\d+)?)?(?:\\s*,\\s*\\d+(?:-\\d+)?)*';
+
+  return new RegExp(`(?:${bookPattern})${chapterVersePattern}`, 'giu');
+}

--- a/src/utils/linkUnlinkedBibleReferences.ts
+++ b/src/utils/linkUnlinkedBibleReferences.ts
@@ -1,7 +1,7 @@
-import { extractBibleReferenceFromMatch } from '@/utils/parseBibleReference';
+import { parseBibleReference } from '@/utils/parseBibleReference';
 import { convertBibleTextToMarkdownLink } from '@/utils/convertBibleTextToMarkdownLink';
 import type { BibleReference, LinkReplacerSettings } from '@/types';
-import { BIBLE_REFERENCE_REGEX } from '@/utils/bibleReferenceRegex';
+import { buildBookNameRegex } from '@/utils/buildBookNameRegex';
 import { logger } from '@/utils/logger';
 
 type Change = {
@@ -16,6 +16,7 @@ export function linkUnlinkedBibleReferences(
   callback: (settings: { changes: Change[]; error: string | undefined }) => void,
 ): void {
   const lines = currentContent.split('\n');
+  const regex = buildBookNameRegex(settings.language);
 
   const foundReferences: {
     line: number;
@@ -27,28 +28,27 @@ export function linkUnlinkedBibleReferences(
   // Scan each line for Bible references using the findBibleReferenceRegex
   lines.forEach((line, lineIndex) => {
     let match;
-    while ((match = BIBLE_REFERENCE_REGEX.exec(line)) !== null) {
-      const result = extractBibleReferenceFromMatch(match[0], settings.language);
-
-      if (!result) {
-        logger.error('Invalid reference', { line, match, lineIndex });
-        continue;
-      }
-
-      const actualIndex = match.index + result.offset;
-      const actualText = result.text;
-
+    while ((match = regex.exec(line)) !== null) {
       // check if match is already a link
-      if (line.includes(`[${actualText}]`)) {
+      if (line.includes(`[${match[0]}]`)) {
         continue;
       }
 
-      foundReferences.push({
-        line: lineIndex,
-        index: actualIndex,
-        text: actualText,
-        reference: result.reference,
-      });
+      try {
+        const reference = parseBibleReference(match[0], settings.language);
+        if (reference) {
+          foundReferences.push({
+            line: lineIndex,
+            index: match.index,
+            text: match[0],
+            reference: reference,
+          });
+        }
+      } catch {
+        logger.error('Invalid reference', { line, match, lineIndex });
+        // Skip invalid references
+        continue;
+      }
     }
   });
 

--- a/src/utils/parseBibleReference.ts
+++ b/src/utils/parseBibleReference.ts
@@ -100,13 +100,42 @@ export function parseBibleReference(input: string, language: Language): BibleRef
 
   // Match book, chapter, and verses part
   // Supports both "Book chapter:verse" and "Book verse" (for single-chapter books)
-  const match = input.match(new RegExp(`^([\\p{L}0-9]+?)(\\d+.*)$`, 'iu'));
+  const greedyMatch = input.match(new RegExp(`^([\\p{L}0-9]+?)(\\d+.*)$`, 'iu'));
 
-  if (!match) {
+  if (!greedyMatch) {
     throw new Error('errors.invalidFormat');
   }
 
-  const [, bookName, remainder] = match;
+  let bookName = greedyMatch[1];
+  let remainder = greedyMatch[2];
+
+  // Try extending the book name to resolve digit-boundary ambiguity.
+  // e.g., for "요한1서1:1", the non-greedy regex captures "요한" + "1서1:1",
+  // but we need "요한1서" + "1:1" to correctly identify 1 John.
+  const fullPrefix = bookName + remainder;
+  const colonIdx = fullPrefix.indexOf(':');
+  if (colonIdx > 0) {
+    const beforeColon = fullPrefix.substring(0, colonIdx);
+    // Try progressively longer book names (from longest to the greedy minimum)
+    for (let i = beforeColon.length - 1; i > bookName.length - 1; i--) {
+      const candidateBook = beforeColon.substring(0, i);
+      const candidateRemainder = fullPrefix.substring(i);
+      // Only consider if remainder starts with a digit (valid chapter start)
+      if (/^\d/.test(candidateRemainder)) {
+        try {
+          const result = findBook(candidateBook, language);
+          if (result && !Array.isArray(result)) {
+            bookName = candidateBook;
+            remainder = candidateRemainder;
+            break;
+          }
+        } catch {
+          // Book not found with this prefix length, try shorter
+          continue;
+        }
+      }
+    }
+  }
 
   // Check if remainder contains a colon (chapter:verse format)
   const colonIndex = remainder.indexOf(':');


### PR DESCRIPTION
## Summary

Fixes Bible book name matching for Korean, Vietnamese, and other languages where book names contain spaces, hyphens, or embedded digits.

- **`/b` explicit mode**: Bypasses the generic regex gate and trusts `parseBibleReference` directly — matches all book name formats
- **Bulk convert**: Uses a new data-driven regex built from actual YAML book names instead of the generic pattern
- **Silent mode**: Now supports hyphenated book names (e.g., Vietnamese `Lê-vi`, `Ru-tơ`)
- **Normalization**: `cleanTerm` and `parseBibleReference` now strip hyphens for consistent matching
- **Korean digit-suffix**: Resolves ambiguity for `요1`/`요2`/`요3` (1/2/3 John short names) via greedy-then-shrink extraction

### What's fixed per mode

| Input | Silent | `/b` | Bulk |
|---|---|---|---|
| `요1 1:1` (KO 1 John short) | — | ✅ | ✅ |
| `요한 1서 1:1` (KO 1 John long) | — | ✅ | ✅ |
| `요한 계시록 1:1` (KO Revelation) | — | ✅ | ✅ |
| `Lê-vi 25:1` (VT Leviticus) | ✅ | ✅ | ✅ |
| `Sáng thế 1:1` (VT Genesis) | — | ✅ | ✅ |
| `1 Sa-mu-ên 3:1` (VT 1 Samuel) | — | ✅ | ✅ |

Closes #235

## Test plan

- [x] 23 new tests added (216 total, all passing)
- [x] Lint clean, type-check clean
- [x] Manual test: `/b 요한 1서 1:1` in Korean mode → suggests 1 John link
- [x] Manual test: `/b Lê-vi 25:1` in Vietnamese mode → suggests Leviticus link
- [x] Manual test: Bulk convert with Korean multi-word references
- [x] Manual test: Silent mode with Vietnamese hyphenated names

🤖 Generated with [Claude Code](https://claude.com/claude-code)