### PR TITLE
Sign language support

### DIFF
--- a/.changeset/add-sign-language-support.md
+++ b/.changeset/add-sign-language-support.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': minor
+---
+
+Add sign language support: 43 sign languages (ASL, BSL, DGS, SLV, and more) are now available in the language settings. Sign languages reuse Bible book names from their related spoken language while using their own wtlocale code in generated links (e.g. `jwlibrary:///finder?bible=40024014&wtlocale=ASL`).

--- a/src/__tests__/signLanguage.test.ts
+++ b/src/__tests__/signLanguage.test.ts
@@ -1,0 +1,98 @@
+import { loadBibleBooks, getBibleBooks, __getCache } from '@/stores/bibleBooks';
+import { formatJWLibraryLink } from '@/utils/formatJWLibraryLink';
+import { getBookLanguage, SIGN_LANGUAGE_MAP } from '@/utils/signLanguage';
+import type { BibleReference } from '@/types';
+import { initializeTestBibleBooks } from '@/__tests__/__helpers__/initializeBibleBooksForTests';
+
+beforeEach(() => {
+  __getCache().clear();
+});
+
+describe('SIGN_LANGUAGE_MAP', () => {
+  test('ASL maps to English', () => {
+    expect(SIGN_LANGUAGE_MAP['ASL']).toBe('E');
+  });
+
+  test('SLV maps to Vietnamese', () => {
+    expect(SIGN_LANGUAGE_MAP['SLV']).toBe('VT');
+  });
+
+  test('DGS maps to German', () => {
+    expect(SIGN_LANGUAGE_MAP['DGS']).toBe('X');
+  });
+});
+
+describe('getBookLanguage', () => {
+  test('returns same language for spoken languages', () => {
+    expect(getBookLanguage('E')).toBe('E');
+    expect(getBookLanguage('X')).toBe('X');
+    expect(getBookLanguage('VT')).toBe('VT');
+  });
+
+  test('resolves sign languages to their spoken base', () => {
+    expect(getBookLanguage('ASL')).toBe('E');
+    expect(getBookLanguage('SLV')).toBe('VT');
+    expect(getBookLanguage('DGS')).toBe('X');
+    expect(getBookLanguage('KSL')).toBe('KO');
+    expect(getBookLanguage('HZJ')).toBe('C');
+  });
+});
+
+describe('loadBibleBooks / getBibleBooks for sign languages', () => {
+  beforeEach(() => {
+    initializeTestBibleBooks(['E', 'X', 'VT']);
+  });
+
+  test('ASL returns the same books as English', () => {
+    loadBibleBooks('ASL');
+    const aslBooks = getBibleBooks('ASL');
+    const englishBooks = getBibleBooks('E');
+    expect(aslBooks).toBe(englishBooks);
+  });
+
+  test('DGS returns the same books as German', () => {
+    loadBibleBooks('DGS');
+    const dgsBooks = getBibleBooks('DGS');
+    const germanBooks = getBibleBooks('X');
+    expect(dgsBooks).toBe(germanBooks);
+  });
+
+  test('SLV returns the same books as Vietnamese', () => {
+    loadBibleBooks('SLV');
+    const slvBooks = getBibleBooks('SLV');
+    const vtBooks = getBibleBooks('VT');
+    expect(slvBooks).toBe(vtBooks);
+  });
+
+  test('second loadBibleBooks call is a no-op', () => {
+    loadBibleBooks('ASL');
+    loadBibleBooks('ASL');
+    expect(getBibleBooks('ASL')).toBe(getBibleBooks('E'));
+  });
+});
+
+describe('formatJWLibraryLink uses sign language code as wtlocale', () => {
+  const reference: BibleReference = {
+    book: 40,
+    chapter: 24,
+    verseRanges: [{ start: 14, end: 14 }],
+  };
+
+  test('ASL produces wtlocale=ASL', () => {
+    expect(formatJWLibraryLink(reference, 'ASL')).toBe(
+      'jwlibrary:///finder?bible=40024014&wtlocale=ASL',
+    );
+  });
+
+  test('SLV produces wtlocale=SLV', () => {
+    expect(formatJWLibraryLink(reference, 'SLV')).toBe(
+      'jwlibrary:///finder?bible=40024014&wtlocale=SLV',
+    );
+  });
+
+  test('DGS produces wtlocale=DGS', () => {
+    expect(formatJWLibraryLink(reference, 'DGS')).toBe(
+      'jwlibrary:///finder?bible=40024014&wtlocale=DGS',
+    );
+  });
+});

--- a/src/consts/languages.json
+++ b/src/consts/languages.json
@@ -88,5 +88,356 @@
     "name": "German",
     "isSignLanguage": false,
     "isRTL": false
+  },
+  {
+    "code": "ASL",
+    "locale": "ase",
+    "vernacular": "American Sign Language",
+    "script": "ROMAN",
+    "name": "American Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSA",
+    "locale": "aed",
+    "vernacular": "lengua de señas argentina",
+    "script": "ROMAN",
+    "name": "Argentinean Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "AUS",
+    "locale": "asf",
+    "vernacular": "Auslan (Australian Sign Language)",
+    "script": "ROMAN",
+    "name": "Australian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "OGS",
+    "locale": "asq",
+    "vernacular": "Österreichische Gebärdensprache",
+    "script": "ROMAN",
+    "name": "Austrian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SBF",
+    "locale": "sfb",
+    "vernacular": "Langue des signes de Belgique francophone",
+    "script": "ROMAN",
+    "name": "Belgian French Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "BVL",
+    "locale": "bvl",
+    "vernacular": "lengua de señas boliviana",
+    "script": "ROMAN",
+    "name": "Bolivian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "BSL",
+    "locale": "bfi",
+    "vernacular": "British Sign Language",
+    "script": "ROMAN",
+    "name": "British Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "BFL",
+    "locale": "sgn_bf",
+    "vernacular": "Burkina Faso Sign Language",
+    "script": "ROMAN",
+    "name": "Burkina Faso Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "CRS",
+    "locale": "sgn_cf",
+    "vernacular": "Langue des signes centrafricaine",
+    "script": "ROMAN",
+    "name": "Central African Republic Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SCH",
+    "locale": "csg",
+    "vernacular": "lengua de señas chilena",
+    "script": "ROMAN",
+    "name": "Chilean Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSC",
+    "locale": "csn",
+    "vernacular": "lengua de señas colombiana",
+    "script": "ROMAN",
+    "name": "Colombian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SCR",
+    "locale": "csr",
+    "vernacular": "lengua de señas costarricense",
+    "script": "ROMAN",
+    "name": "Costa Rican Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "HZJ",
+    "locale": "csq",
+    "vernacular": "hrvatski znakovni jezik",
+    "script": "ROMAN",
+    "name": "Croatian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "CBS",
+    "locale": "csf",
+    "vernacular": "lengua de señas cubana",
+    "script": "ROMAN",
+    "name": "Cuban Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "NGT",
+    "locale": "dse",
+    "vernacular": "Nederlandse Gebarentaal",
+    "script": "ROMAN",
+    "name": "Dutch Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SEC",
+    "locale": "ecs",
+    "vernacular": "lengua de señas ecuatoriana",
+    "script": "ROMAN",
+    "name": "Ecuadorian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "FID",
+    "locale": "fse",
+    "vernacular": "suomalainen viittomakieli",
+    "script": "ROMAN",
+    "name": "Finnish Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSF",
+    "locale": "fsl",
+    "vernacular": "Langue des signes française",
+    "script": "ROMAN",
+    "name": "French Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "DGS",
+    "locale": "gsg",
+    "vernacular": "Deutsche Gebärdensprache",
+    "script": "ROMAN",
+    "name": "German Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSG",
+    "locale": "gsm",
+    "vernacular": "lengua de señas de Guatemala",
+    "script": "ROMAN",
+    "name": "Guatemalan Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SHO",
+    "locale": "hds",
+    "vernacular": "lengua de señas hondureña",
+    "script": "ROMAN",
+    "name": "Honduras Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "ISG",
+    "locale": "isg",
+    "vernacular": "Irish Sign Language",
+    "script": "ROMAN",
+    "name": "Irish Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSI",
+    "locale": "sgn_ci",
+    "vernacular": "Langue des signes ivoirienne",
+    "script": "ROMAN",
+    "name": "Ivorian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "JML",
+    "locale": "jls",
+    "vernacular": "Jamaican Sign Language",
+    "script": "ROMAN",
+    "name": "Jamaican Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "KSL",
+    "locale": "kvk",
+    "vernacular": "한국 수어",
+    "script": "KOREAN",
+    "name": "Korean Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "CML",
+    "locale": "sgn_cm",
+    "vernacular": "Langue des signes camerounaise",
+    "script": "ROMAN",
+    "name": "Langue des signes camerounaise",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSM",
+    "locale": "mfs",
+    "vernacular": "lengua de señas mexicana",
+    "script": "ROMAN",
+    "name": "Mexican Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "NZS",
+    "locale": "nzs",
+    "vernacular": "New Zealand Sign Language",
+    "script": "ROMAN",
+    "name": "New Zealand Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSN",
+    "locale": "ncs",
+    "vernacular": "lenguaje de señas nicaragüense",
+    "script": "ROMAN",
+    "name": "Nicaraguan Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "PSL",
+    "locale": "lsp",
+    "vernacular": "lengua de señas panameñas",
+    "script": "ROMAN",
+    "name": "Panamanian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSP",
+    "locale": "pys",
+    "vernacular": "lengua de señas paraguaya",
+    "script": "ROMAN",
+    "name": "Paraguayan Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SPE",
+    "locale": "prl",
+    "vernacular": "lengua de señas peruana",
+    "script": "ROMAN",
+    "name": "Peruvian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LGP",
+    "locale": "psr",
+    "vernacular": "Língua Gestual Portuguesa",
+    "script": "ROMAN",
+    "name": "Portuguese Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSQ",
+    "locale": "fcs",
+    "vernacular": "Langue des signes québécoise",
+    "script": "ROMAN",
+    "name": "Quebec Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSS",
+    "locale": "esn",
+    "vernacular": "lengua de señas salvadoreña",
+    "script": "ROMAN",
+    "name": "Salvadoran Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSE",
+    "locale": "ssp",
+    "vernacular": "lengua de signos española",
+    "script": "ROMAN",
+    "name": "Spanish Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSU",
+    "locale": "ugy",
+    "vernacular": "lengua de señas uruguaya",
+    "script": "ROMAN",
+    "name": "Uruguayan Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LSV",
+    "locale": "vsl",
+    "vernacular": "lengua de señas venezolana",
+    "script": "ROMAN",
+    "name": "Venezuelan Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SLV",
+    "locale": "hab",
+    "vernacular": "Việt Nam (Ngôn ngữ ký hiệu)",
+    "script": "ROMAN",
+    "name": "Vietnamese Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
   }
 ]

--- a/src/consts/languages.ts
+++ b/src/consts/languages.ts
@@ -5,7 +5,7 @@ import languageJson from '@/consts/languages.json';
  * Central language configuration.
  */
 export const LANGUAGES: Record<Language, LanguageInfo> = Object.fromEntries(
-  languageJson.map((lang) => [lang.code as Language, lang as LanguageInfo]),
+  languageJson.map((lang) => [lang.code as Language, lang]),
 ) as Record<Language, LanguageInfo>;
 
 type LanguageInfoPlus = Omit<LanguageInfo, 'code'> & { code: Language };

--- a/src/consts/languagesUnsupported.json
+++ b/src/consts/languagesUnsupported.json
@@ -1,9760 +1,9407 @@
-{
-    "languages": [
-        {
-            "code": "ABN",
-            "locale": "abx",
-            "vernacular": "Abaknon",
-            "script": "ROMAN",
-            "name": "Abaknon",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ABB",
-            "locale": "aba",
-            "vernacular": "Abɛ",
-            "script": "ROMAN",
-            "name": "Abbey",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ABK",
-            "locale": "ab",
-            "vernacular": "аԥсуа",
-            "script": "CYRILLIC",
-            "name": "Abkhaz",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AU",
-            "locale": "abn",
-            "vernacular": "Abua",
-            "script": "ROMAN",
-            "name": "Abua",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ABU",
-            "locale": "abz",
-            "vernacular": "Alor Abui",
-            "script": "ROMAN",
-            "name": "Abui",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ACD",
-            "locale": "fr_x_acd",
-            "vernacular": "Acadien",
-            "script": "ROMAN",
-            "name": "Acadian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ACH",
-            "locale": "acr",
-            "vernacular": "achi",
-            "script": "ROMAN",
-            "name": "Achi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ACC",
-            "locale": "acr_x_acc",
-            "vernacular": "achí de cubulco",
-            "script": "ROMAN",
-            "name": "Achi (Cubulco)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ACR",
-            "locale": "acr_x_acr",
-            "vernacular": "achí de rabinal",
-            "script": "ROMAN",
-            "name": "Achi (Rabinal)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AC",
-            "locale": "ach",
-            "vernacular": "Acholi",
-            "script": "ROMAN",
-            "name": "Acholi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AHW",
-            "locale": "acu",
-            "vernacular": "achuar-shiwiar",
-            "script": "ROMAN",
-            "name": "Achuar-Shiwiar",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ADH",
-            "locale": "adh",
-            "vernacular": "Dhopadhola",
-            "script": "ROMAN",
-            "name": "Adhola",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AD",
-            "locale": "ady",
-            "vernacular": "адыгабзэ",
-            "script": "CYRILLIC",
-            "name": "Adyghe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AF",
-            "locale": "af",
-            "vernacular": "Afrikaans",
-            "script": "ROMAN",
-            "name": "Afrikaans",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AHN",
-            "locale": "aha",
-            "vernacular": "Aɣɩnda",
-            "script": "ROMAN",
-            "name": "Ahanta",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AJG",
-            "locale": "ajg",
-            "vernacular": "Aja",
-            "script": "ROMAN",
-            "name": "Aja",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HO",
-            "locale": "aji",
-            "vernacular": "A'jië",
-            "script": "ROMAN",
-            "name": "Ajië",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KAN",
-            "locale": "knj",
-            "vernacular": "akateko",
-            "script": "ROMAN",
-            "name": "Akateko",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AKA",
-            "locale": "ahk",
-            "vernacular": "Akha",
-            "script": "ROMAN",
-            "name": "Akha",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AL",
-            "locale": "sq",
-            "vernacular": "shqip",
-            "script": "ROMAN",
-            "name": "Albanian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ALG",
-            "locale": "aln",
-            "vernacular": "Albanian (Gheg)",
-            "script": "ROMAN",
-            "name": "Albanian (Gheg)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ALS",
-            "locale": "sqk",
-            "vernacular": "shqipe e shenjave",
-            "script": "ROMAN",
-            "name": "Albanian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "ALQ",
-            "locale": "alq",
-            "vernacular": "Anishinàbemowin",
-            "script": "ROMAN",
-            "name": "Algonquin",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LTN",
-            "locale": "gsw_x_ltn",
-            "vernacular": "Elsässisch",
-            "script": "ROMAN",
-            "name": "Alsatian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ALT",
-            "locale": "alt",
-            "vernacular": "алтай",
-            "script": "CYRILLIC",
-            "name": "Altai",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ALU",
-            "locale": "alz",
-            "vernacular": "Alur",
-            "script": "ROMAN",
-            "name": "Alur",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ABE",
-            "locale": "omb",
-            "vernacular": "Ambae (East)",
-            "script": "ROMAN",
-            "name": "Ambae (East)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ASL",
-            "locale": "ase",
-            "vernacular": "American Sign Language",
-            "script": "ROMAN",
-            "name": "American Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "AM",
-            "locale": "am",
-            "vernacular": "አማርኛ",
-            "script": "ETHIOPIC",
-            "name": "Amharic",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AI",
-            "locale": "ami",
-            "vernacular": "阿美語",
-            "script": "ROMAN",
-            "name": "Amis",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AMG",
-            "locale": "amu",
-            "vernacular": "ñoomndaa",
-            "script": "ROMAN",
-            "name": "Amuzgo (Guerrero)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ANM",
-            "locale": "anm",
-            "vernacular": "Anal",
-            "script": "ROMAN",
-            "name": "Anal",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LAS",
-            "locale": "sgn_ao",
-            "vernacular": "Língua angolana de sinais",
-            "script": "ROMAN",
-            "name": "Angolan Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "AYI",
-            "locale": "any_ci",
-            "vernacular": "anyin (indenie)",
-            "script": "ROMAN",
-            "name": "Anyin (Indenie)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "APM",
-            "locale": "app",
-            "vernacular": "Apma",
-            "script": "ROMAN",
-            "name": "Apma",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "A",
-            "locale": "ar",
-            "vernacular": "العربية",
-            "script": "ARABIC",
-            "name": "Arabic",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "ADZ",
-            "locale": "arq",
-            "vernacular": "العربيّة (الدّارجة الجزائريّة)",
-            "script": "ARABIC",
-            "name": "Arabic (Algeria)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "AEY",
-            "locale": "arz",
-            "vernacular": "العربية (اللهجة المصرية)",
-            "script": "ARABIC",
-            "name": "Arabic (Egypt)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "ARQ",
-            "locale": "acm",
-            "vernacular": "العربية (اللهجة‏ ‏العراقية)‏",
-            "script": "ARABIC",
-            "name": "Arabic (Iraq)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "AJD",
-            "locale": "ajp",
-            "vernacular": "العربية (اللهجة‏ ‏الأردنية)‏",
-            "script": "ARABIC",
-            "name": "Arabic (Jordan)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "ALN",
-            "locale": "apc",
-            "vernacular": "العربية (اللهجة اللبنانية)",
-            "script": "ARABIC",
-            "name": "Arabic (Lebanon)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "AMO",
-            "locale": "ary",
-            "vernacular": "العربية (الدارجة المغربية)",
-            "script": "ARABIC",
-            "name": "Arabic (Morocco)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "JU",
-            "locale": "pga",
-            "vernacular": "Arabi Juba",
-            "script": "ROMAN",
-            "name": "Arabic (Sudanese Creole)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ASN",
-            "locale": "apd",
-            "vernacular": "العربية (اللهجة السودانية)",
-            "script": "ARABIC",
-            "name": "Arabic (Sudanese)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "ASR",
-            "locale": "apc_sy",
-            "vernacular": "العربية (اللهجة‏ السورية)‏",
-            "script": "ARABIC",
-            "name": "Arabic (Syria)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "ATN",
-            "locale": "aeb",
-            "vernacular": "العربية (الدّارجة‏ ‏التّونسيّة)",
-            "script": "ARABIC",
-            "name": "Arabic (Tunisia)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "LSA",
-            "locale": "aed",
-            "vernacular": "lengua de señas argentina",
-            "script": "ROMAN",
-            "name": "Argentinean Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "ARH",
-            "locale": "arh",
-            "vernacular": "Arhuaco",
-            "script": "ROMAN",
-            "name": "Arhuaco",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "REA",
-            "locale": "hy",
-            "vernacular": "Հայերեն",
-            "script": "ARMENIAN",
-            "name": "Armenian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KRB",
-            "locale": "hy_x_krb",
-            "vernacular": "Հայերեն (արևելյան բարբառ)",
-            "script": "ARMENIAN",
-            "name": "Armenian (Eastern dialect)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "R",
-            "locale": "hyw",
-            "vernacular": "Արեւմտահայերէն",
-            "script": "ARMENIAN",
-            "name": "Armenian (West)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ARS",
-            "locale": "aen",
-            "vernacular": "Հայերեն ժեստերի լեզու",
-            "script": "ARMENIAN",
-            "name": "Armenian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "AHK",
-            "locale": "cni",
-            "vernacular": "ashaninka",
-            "script": "ROMAN",
-            "name": "Ashaninka",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AE",
-            "locale": "as",
-            "vernacular": "অসমীয়া",
-            "script": "BENGALI",
-            "name": "Assamese",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AS",
-            "locale": "aii",
-            "vernacular": "ܐܵܬܘܿܪܵܝܵܐ",
-            "script": "ASSYRIAN",
-            "name": "Assyrian",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "ACS",
-            "locale": "cld",
-            "vernacular": "Assyro-Chaldean (Silopi)",
-            "script": "ASSYRIAN",
-            "name": "Assyro-Chaldean (Silopi)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ATY",
-            "locale": "tay",
-            "vernacular": "Tayal",
-            "script": "ROMAN",
-            "name": "Atayal",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IE",
-            "locale": "teo",
-            "vernacular": "Ateso",
-            "script": "ROMAN",
-            "name": "Ateso",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ATI",
-            "locale": "ati",
-            "vernacular": "Akie",
-            "script": "ROMAN",
-            "name": "Attié",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AKN",
-            "locale": "djk",
-            "vernacular": "Okanisitongo",
-            "script": "ROMAN",
-            "name": "Aukan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AUS",
-            "locale": "asf",
-            "vernacular": "Auslan (Australian Sign Language)",
-            "script": "ROMAN",
-            "name": "Australian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "OGS",
-            "locale": "asq",
-            "vernacular": "Österreichische Gebärdensprache",
-            "script": "ROMAN",
-            "name": "Austrian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "AV",
-            "locale": "av",
-            "vernacular": "магӀарул",
-            "script": "CYRILLIC",
-            "name": "Avar",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AWA",
-            "locale": "kwi",
-            "vernacular": "awapit",
-            "script": "ROMAN",
-            "name": "Awa (Cuaiquer)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AWD",
-            "locale": "awa",
-            "vernacular": "Awadhi",
-            "script": "DEVANAGARI",
-            "name": "Awadhi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AGR",
-            "locale": "agr",
-            "vernacular": "awajun",
-            "script": "ROMAN",
-            "name": "Awajun",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AWN",
-            "locale": "azo",
-            "vernacular": "Awing",
-            "script": "ROMAN",
-            "name": "Awing",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AP",
-            "locale": "ay",
-            "vernacular": "Aymara",
-            "script": "ROMAN",
-            "name": "Aymara",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AJR",
-            "locale": "az",
-            "vernacular": "Azərbaycan",
-            "script": "ROMAN",
-            "name": "Azerbaijani",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AJA",
-            "locale": "azb",
-            "vernacular": "آذربايجانى (عربى)",
-            "script": "ARABIC",
-            "name": "Azerbaijani (Arabic)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "AJ",
-            "locale": "az_cyrl",
-            "vernacular": "Aзәрбајҹан (кирил әлифбасы)",
-            "script": "CYRILLIC",
-            "name": "Azerbaijani (Cyrillic)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FNB",
-            "locale": "wyy_x_fnb",
-            "vernacular": "Ba",
-            "script": "ROMAN",
-            "name": "Ba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BCM",
-            "locale": "bcy",
-            "vernacular": "Bacama",
-            "script": "ROMAN",
-            "name": "Bacama",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BDG",
-            "locale": "bfq",
-            "vernacular": "படகா",
-            "script": "TAMIL",
-            "name": "Badaga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BFI",
-            "locale": "ksf",
-            "vernacular": "bafia (rikpag)",
-            "script": "ROMAN",
-            "name": "Bafia",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BNR",
-            "locale": "bdq",
-            "vernacular": "Bahnar",
-            "script": "ROMAN",
-            "name": "Bahnar",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BKK",
-            "locale": "bkh",
-            "vernacular": "Bakoko",
-            "script": "ROMAN",
-            "name": "Bakoko",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BLN",
-            "locale": "ban",
-            "vernacular": "Bali",
-            "script": "ROMAN",
-            "name": "Balinese",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AR",
-            "locale": "bm",
-            "vernacular": "Bamanankan",
-            "script": "ROMAN",
-            "name": "Bambara",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BMN",
-            "locale": "bax",
-            "vernacular": "Shü Pamom",
-            "script": "ROMAN",
-            "name": "Bamun",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BNM",
-            "locale": "bjo",
-            "vernacular": "Banda (Mid-Southern)",
-            "script": "ROMAN",
-            "name": "Banda (Mid-Southern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BNW",
-            "locale": "bwi",
-            "vernacular": "Baniua",
-            "script": "ROMAN",
-            "name": "Baniwa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BNJ",
-            "locale": "bjn",
-            "vernacular": "Banjar",
-            "script": "ROMAN",
-            "name": "Banjar",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AO",
-            "locale": "bci",
-            "vernacular": "Wawle",
-            "script": "ROMAN",
-            "name": "Baoule",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BH",
-            "locale": "bfa",
-            "vernacular": "Bari",
-            "script": "ROMAN",
-            "name": "Bari",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BB",
-            "locale": "bba",
-            "vernacular": "Baatɔnum",
-            "script": "ROMAN",
-            "name": "Bariba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BRW",
-            "locale": "bwg",
-            "vernacular": "Barwe",
-            "script": "ROMAN",
-            "name": "Barwe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BSA",
-            "locale": "mot",
-            "vernacular": "Barí (South America)",
-            "script": "ROMAN",
-            "name": "Barí (South America)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BAK",
-            "locale": "ba",
-            "vernacular": "башҡорт",
-            "script": "CYRILLIC",
-            "name": "Bashkir",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BQ",
-            "locale": "eu",
-            "vernacular": "Euskara",
-            "script": "ROMAN",
-            "name": "Basque",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BS",
-            "locale": "bas",
-            "vernacular": "Basaa (Kamerun)",
-            "script": "ROMAN",
-            "name": "Bassa (Cameroon)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BA",
-            "locale": "bsq",
-            "vernacular": "Ɓǎsɔ́ɔ̀ (Ɖàbíɖà)",
-            "script": "ROMAN",
-            "name": "Bassa (Liberia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BTD",
-            "locale": "btd",
-            "vernacular": "Pakpak",
-            "script": "ROMAN",
-            "name": "Batak (Dairi)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AK",
-            "locale": "btx",
-            "vernacular": "Batak (Karo)",
-            "script": "ROMAN",
-            "name": "Batak (Karo)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BTK",
-            "locale": "bts",
-            "vernacular": "Batak (Simalungun)",
-            "script": "ROMAN",
-            "name": "Batak (Simalungun)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BT",
-            "locale": "bbc",
-            "vernacular": "Batak (Toba)",
-            "script": "ROMAN",
-            "name": "Batak (Toba)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BEA",
-            "locale": "ron_x_bea",
-            "vernacular": "Beas",
-            "script": "ROMAN",
-            "name": "Beas",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SBF",
-            "locale": "sfb",
-            "vernacular": "Langue des signes de Belgique francophone",
-            "script": "ROMAN",
-            "name": "Belgian French Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "BZK",
-            "locale": "bzj",
-            "vernacular": "Bileez Kriol",
-            "script": "ROMAN",
-            "name": "Belize Kriol",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BEL",
-            "locale": "be",
-            "vernacular": "беларуская",
-            "script": "CYRILLIC",
-            "name": "Belorussian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BMB",
-            "locale": "bmb",
-            "vernacular": "Kibembe",
-            "script": "ROMAN",
-            "name": "Bembe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "EN",
-            "locale": "bez",
-            "vernacular": "Bena",
-            "script": "ROMAN",
-            "name": "Bena",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BE",
-            "locale": "bn",
-            "vernacular": "বাংলা",
-            "script": "BENGALI",
-            "name": "Bengali",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BNL",
-            "locale": "sgn_bj",
-            "vernacular": "Benin Sign Language",
-            "script": "ROMAN",
-            "name": "Benin Sign Language",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BRM",
-            "locale": "bom",
-            "vernacular": "Berom",
-            "script": "ROMAN",
-            "name": "Berom",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BTO",
-            "locale": "plt_x_bto",
-            "vernacular": "Betsileo",
-            "script": "ROMAN",
-            "name": "Betsileo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BTS",
-            "locale": "bmm",
-            "vernacular": "Betsimisaraka Avaratra",
-            "script": "ROMAN",
-            "name": "Betsimisaraka (Northern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BTA",
-            "locale": "bzc",
-            "vernacular": "Betsimisaraka Atsimo",
-            "script": "ROMAN",
-            "name": "Betsimisaraka (Southern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BHJ",
-            "locale": "bho",
-            "vernacular": "भोजपुरी",
-            "script": "DEVANAGARI",
-            "name": "Bhojpuri",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BHM",
-            "locale": "bho_mu",
-            "vernacular": "Bhojpuri (Mauritius)",
-            "script": "ROMAN",
-            "name": "Bhojpuri (Mauritius)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IK",
-            "locale": "bhw",
-            "vernacular": "Biak",
-            "script": "ROMAN",
-            "name": "Biak",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BI",
-            "locale": "bcl",
-            "vernacular": "Bicol",
-            "script": "ROMAN",
-            "name": "Bicol",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BDY",
-            "locale": "sdo",
-            "vernacular": "Bidayuh (Bukar)",
-            "script": "ROMAN",
-            "name": "Bidayuh (Bukar)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BLB",
-            "locale": "bib",
-            "vernacular": "Bɩsa",
-            "script": "ROMAN",
-            "name": "Bisa (Lebir)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LM",
-            "locale": "bi",
-            "vernacular": "Bislama",
-            "script": "ROMAN",
-            "name": "Bislama",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TCR",
-            "locale": "pov",
-            "vernacular": "Kriol di Gine-Bisau",
-            "script": "ROMAN",
-            "name": "Bissau Guinean Creole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BNS",
-            "locale": "bps",
-            "vernacular": "Blaan (Sarangani)",
-            "script": "ROMAN",
-            "name": "Blaan (Sarangani)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BLF",
-            "locale": "bla",
-            "vernacular": "Siksikáíitsi'powahsini",
-            "script": "ROMAN",
-            "name": "Blackfoot",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BVL",
-            "locale": "bvl",
-            "vernacular": "lengua de señas boliviana",
-            "script": "ROMAN",
-            "name": "Bolivian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "BMU",
-            "locale": "bmq",
-            "vernacular": "Boomu",
-            "script": "ROMAN",
-            "name": "Bomu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BSN",
-            "locale": "bs",
-            "vernacular": "bosanski",
-            "script": "ROMAN",
-            "name": "Bosnian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WSL",
-            "locale": "sgn_bw",
-            "vernacular": "Botswana Sign Language",
-            "script": "ROMAN",
-            "name": "Botswana Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "BO",
-            "locale": "bum",
-            "vernacular": "Bulu",
-            "script": "ROMAN",
-            "name": "Boulou",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSB",
-            "locale": "bzs",
-            "vernacular": "Língua brasileira de sinais (Libras)",
-            "script": "ROMAN",
-            "name": "Brazilian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "BRI",
-            "locale": "bzd",
-            "vernacular": "bribri",
-            "script": "ROMAN",
-            "name": "Bribri",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BSL",
-            "locale": "bfi",
-            "vernacular": "British Sign Language",
-            "script": "ROMAN",
-            "name": "British Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "BDZ",
-            "locale": "bja",
-            "vernacular": "Ebudza",
-            "script": "ROMAN",
-            "name": "Budza",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LK",
-            "locale": "bxk",
-            "vernacular": "Bukusu",
-            "script": "ROMAN",
-            "name": "Bukusu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BL",
-            "locale": "bg",
-            "vernacular": "български",
-            "script": "CYRILLIC",
-            "name": "Bulgarian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BLS",
-            "locale": "bqn",
-            "vernacular": "български жестов език",
-            "script": "CYRILLIC",
-            "name": "Bulgarian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "BNN",
-            "locale": "bnn",
-            "vernacular": "布農語（南部）",
-            "script": "ROMAN",
-            "name": "Bunun (South)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BUR",
-            "locale": "bwr",
-            "vernacular": "Bura",
-            "script": "ROMAN",
-            "name": "Bura",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BFL",
-            "locale": "sgn_bf",
-            "vernacular": "Burkina Faso Sign Language",
-            "script": "ROMAN",
-            "name": "Burkina Faso Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "BRS",
-            "locale": "sgn_bi",
-            "vernacular": "Langue des signes burundaise",
-            "script": "ROMAN",
-            "name": "Burundi Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "BY",
-            "locale": "bxr",
-            "vernacular": "буряад",
-            "script": "CYRILLIC",
-            "name": "Buryat",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BSH",
-            "locale": "buc",
-            "vernacular": "Kibushi",
-            "script": "ROMAN",
-            "name": "Bushi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BHL",
-            "locale": "lel",
-            "vernacular": "Bushilele",
-            "script": "ROMAN",
-            "name": "Bushilele",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BSG",
-            "locale": "buf",
-            "vernacular": "Bushoong",
-            "script": "ROMAN",
-            "name": "Bushoong",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ET",
-            "locale": "btg",
-            "vernacular": "ˈBhɛtɩgbʋʋ",
-            "script": "ROMAN",
-            "name": "Bété",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CAB",
-            "locale": "cjp",
-            "vernacular": "cabécar",
-            "script": "ROMAN",
-            "name": "Cabécar (Tayní)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CQC",
-            "locale": "cak_x_cqc",
-            "vernacular": "Kaqchikel central",
-            "script": "ROMAN",
-            "name": "Cakchiquel (Central)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CQE",
-            "locale": "cak_x_cqe",
-            "vernacular": "Kaqchikel oriental",
-            "script": "ROMAN",
-            "name": "Cakchiquel (Eastern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CQ",
-            "locale": "cak",
-            "vernacular": "Kaqchikel occidental",
-            "script": "ROMAN",
-            "name": "Cakchiquel (Western)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CB",
-            "locale": "km",
-            "vernacular": "ខ្មែរ",
-            "script": "CAMBODIAN",
-            "name": "Cambodian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CBL",
-            "locale": "sgn_kh",
-            "vernacular": "ភាសាសញ្ញាខ្មែរ",
-            "script": "CAMBODIAN",
-            "name": "Cambodian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "CRB",
-            "locale": "car_x_crb",
-            "vernacular": "Kariʼnia",
-            "script": "ROMAN",
-            "name": "Carib",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AN",
-            "locale": "cat",
-            "vernacular": "català",
-            "script": "ROMAN",
-            "name": "Catalan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CV",
-            "locale": "ceb",
-            "vernacular": "Cebuano",
-            "script": "ROMAN",
-            "name": "Cebuano",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CRS",
-            "locale": "sgn_cf",
-            "vernacular": "Langue des signes centrafricaine",
-            "script": "ROMAN",
-            "name": "Central African Republic Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "YU",
-            "locale": "esu",
-            "vernacular": "Central Alaskan Yupik",
-            "script": "ROMAN",
-            "name": "Central Alaskan Yupik",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CM",
-            "locale": "ch",
-            "vernacular": "Chamorro",
-            "script": "ROMAN",
-            "name": "Chamorro",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CGM",
-            "locale": "tso_mz",
-            "vernacular": "xiChangana (Moçambique)",
-            "script": "ROMAN",
-            "name": "Changana (Mozambique)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CGA",
-            "locale": "tso_zw",
-            "vernacular": "Xichangana (Zimbabwe)",
-            "script": "ROMAN",
-            "name": "Changana (Zimbabwe)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CC",
-            "locale": "cbk",
-            "vernacular": "Chavacano",
-            "script": "ROMAN",
-            "name": "Chavacano",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CPL",
-            "locale": "cbi",
-            "vernacular": "cha'palaa",
-            "script": "ROMAN",
-            "name": "Cha’palaa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HE",
-            "locale": "ce",
-            "vernacular": "нохчийн",
-            "script": "CYRILLIC",
-            "name": "Chechen",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CDG",
-            "locale": "arn_x_cdg",
-            "vernacular": "Chedungun labquenche",
-            "script": "ROMAN",
-            "name": "Chedungun (Coast)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CKE",
-            "locale": "chr",
-            "vernacular": "ᏣᎳᎩ ᎦᏬᏂᎯᏍᏗ",
-            "script": "CHEROKEE",
-            "name": "Cherokee",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CGD",
-            "locale": "hne_deva",
-            "vernacular": "छत्तीसगढ़ी (देवनागरी)",
-            "script": "DEVANAGARI",
-            "name": "Chhattisgarhi (Devanagari)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CN",
-            "locale": "ny",
-            "vernacular": "Chichewa",
-            "script": "ROMAN",
-            "name": "Chichewa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CGG",
-            "locale": "cgg",
-            "vernacular": "Orukiga",
-            "script": "ROMAN",
-            "name": "Chiga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SCH",
-            "locale": "csg",
-            "vernacular": "lengua de señas chilena",
-            "script": "ROMAN",
-            "name": "Chilean Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "FLM",
-            "locale": "cfm",
-            "vernacular": "Chin (Falam)",
-            "script": "ROMAN",
-            "name": "Chin (Falam)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HK",
-            "locale": "cnh",
-            "vernacular": "Chin (Hakha)",
-            "script": "ROMAN",
-            "name": "Chin (Hakha)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KUK",
-            "locale": "tcz",
-            "vernacular": "Chin (Kuki)",
-            "script": "ROMAN",
-            "name": "Chin (Kuki)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MAA",
-            "locale": "mrh",
-            "vernacular": "Chin (Mara)",
-            "script": "ROMAN",
-            "name": "Chin (Mara)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CI",
-            "locale": "ctd",
-            "vernacular": "Chin (Tedim)",
-            "script": "ROMAN",
-            "name": "Chin (Tiddim)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZO",
-            "locale": "czt",
-            "vernacular": "Chin (Zotung)",
-            "script": "ROMAN",
-            "name": "Chin (Zotung)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CNO",
-            "locale": "chj",
-            "vernacular": "jújmi kiʼtsa köwɨ̱",
-            "script": "ROMAN",
-            "name": "Chinantec (Ojitlan)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CHF",
-            "locale": "cdo",
-            "vernacular": "中文（福州话）",
-            "script": "CHINESE",
-            "name": "Chinese (Fuzhounese)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CHG",
-            "locale": "wuu_x_chg",
-            "vernacular": "中文（上海话）",
-            "script": "CHINESE",
-            "name": "Chinese (Shanghainese)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CSN",
-            "locale": "cmn_x_csn",
-            "vernacular": "中文（四川话）",
-            "script": "CHINESE",
-            "name": "Chinese (Sichuanese)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WNZ",
-            "locale": "wuu_x_wnz",
-            "vernacular": "中文（温州话）",
-            "script": "CHINESE",
-            "name": "Chinese (Wenzhounese)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CHK",
-            "locale": "cmn_x_chk",
-            "vernacular": "中文（云南话）",
-            "script": "CHINESE",
-            "name": "Chinese (Yunnanese)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CNS",
-            "locale": "yue_hans",
-            "vernacular": "中文简体（广东话）",
-            "script": "CHINESE",
-            "name": "Chinese Cantonese (Simplified)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CHC",
-            "locale": "yue_hant",
-            "vernacular": "中文繁體（廣東話）",
-            "script": "CHINESE",
-            "name": "Chinese Cantonese (Traditional)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CHS",
-            "locale": "cmn_hans",
-            "vernacular": "中文简体（普通话）",
-            "script": "CHINESE",
-            "name": "Chinese Mandarin (Simplified)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CH",
-            "locale": "cmn_hant",
-            "vernacular": "中文繁體（國語）",
-            "script": "CHINESE",
-            "name": "Chinese Mandarin (Traditional)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CSL",
-            "locale": "csl",
-            "vernacular": "中国手语",
-            "script": "CHINESE",
-            "name": "Chinese Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "CHQ",
-            "locale": "cax",
-            "vernacular": "Chiquitano",
-            "script": "ROMAN",
-            "name": "Chiquitano",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CG",
-            "locale": "toi",
-            "vernacular": "Chitonga",
-            "script": "ROMAN",
-            "name": "Chitonga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CT",
-            "locale": "tog",
-            "vernacular": "Chitonga (Malawi)",
-            "script": "ROMAN",
-            "name": "Chitonga (Malawi)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CGW",
-            "locale": "toi_zw",
-            "vernacular": "Chitonga (Zimbabwe)",
-            "script": "ROMAN",
-            "name": "Chitonga (Zimbabwe)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TB",
-            "locale": "tum",
-            "vernacular": "Chitumbuka",
-            "script": "ROMAN",
-            "name": "Chitumbuka",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YA",
-            "locale": "yao",
-            "vernacular": "Chiyao",
-            "script": "ROMAN",
-            "name": "Chiyao",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CTW",
-            "locale": "cho",
-            "vernacular": "Choctaw",
-            "script": "ROMAN",
-            "name": "Choctaw",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CK",
-            "locale": "cjk",
-            "vernacular": "Chokwe",
-            "script": "ROMAN",
-            "name": "Chokwe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CHL",
-            "locale": "ctu",
-            "vernacular": "ch'ol",
-            "script": "ROMAN",
-            "name": "Chol",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CLX",
-            "locale": "chd",
-            "vernacular": "lataiki",
-            "script": "ROMAN",
-            "name": "Chontal (Oaxaca)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CLT",
-            "locale": "chf",
-            "vernacular": "yokotʼan",
-            "script": "ROMAN",
-            "name": "Chontal (Tabasco)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CPI",
-            "locale": "cce",
-            "vernacular": "Txitxopi",
-            "script": "ROMAN",
-            "name": "Chopi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CTI",
-            "locale": "crt",
-            "vernacular": "chorote (iyojwa'ja)",
-            "script": "ROMAN",
-            "name": "Chorote (Iyojwa'ja)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CO",
-            "locale": "chw",
-            "vernacular": "Etxuwabo",
-            "script": "ROMAN",
-            "name": "Chuabo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CHJ",
-            "locale": "cac",
-            "vernacular": "chuj",
-            "script": "ROMAN",
-            "name": "Chuj",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TE",
-            "locale": "chk",
-            "vernacular": "Chuuk",
-            "script": "ROMAN",
-            "name": "Chuukese",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CU",
-            "locale": "cv",
-            "vernacular": "чӑвашла",
-            "script": "CYRILLIC",
-            "name": "Chuvash",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CW",
-            "locale": "bem",
-            "vernacular": "Cibemba",
-            "script": "ROMAN",
-            "name": "Cibemba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NM",
-            "locale": "mwn",
-            "vernacular": "Cinamwanga",
-            "script": "ROMAN",
-            "name": "Cinamwanga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CIN",
-            "locale": "nya",
-            "vernacular": "Cinyanja",
-            "script": "ROMAN",
-            "name": "Cinyanja",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSC",
-            "locale": "csn",
-            "vernacular": "lengua de señas colombiana",
-            "script": "ROMAN",
-            "name": "Colombian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "CMK",
-            "locale": "cfg",
-            "vernacular": "Como Karim",
-            "script": "ROMAN",
-            "name": "Como Karim",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CMG",
-            "locale": "zdj",
-            "vernacular": "Shikomori (Ngazidja)",
-            "script": "ROMAN",
-            "name": "Comorian (Ngazidja)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CGS",
-            "locale": "sgn_cd",
-            "vernacular": "Langue des signes congolaise",
-            "script": "ROMAN",
-            "name": "Congolese Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "COR",
-            "locale": "crn",
-            "vernacular": "cora (el nayar)",
-            "script": "ROMAN",
-            "name": "Cora (El Nayar)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CSC",
-            "locale": "co",
-            "vernacular": "Corsu",
-            "script": "ROMAN",
-            "name": "Corsican",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SCR",
-            "locale": "csr",
-            "vernacular": "lengua de señas costarricense",
-            "script": "ROMAN",
-            "name": "Costa Rican Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "CY",
-            "locale": "crk_latn",
-            "vernacular": "nēhiyawēwin",
-            "script": "ROMAN",
-            "name": "Cree Plains (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CYS",
-            "locale": "crk_x_cys",
-            "vernacular": "ᓀᐦᐃᔭᐁᐧᐃᐧᐣ",
-            "script": "CANADIAN_SY",
-            "name": "Cree Plains (Syllabics)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CSR",
-            "locale": "crj_latn",
-            "vernacular": "Iinuuayimuwin",
-            "script": "ROMAN",
-            "name": "Cree Southern East (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YC",
-            "locale": "csw_x_yc",
-            "vernacular": "Ininîmowin",
-            "script": "ROMAN",
-            "name": "Cree West Swampy (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YCS",
-            "locale": "csw_x_ycs",
-            "vernacular": "ᐃᓂᓃᒧᐏᐣ",
-            "script": "CANADIAN_SY",
-            "name": "Cree West Swampy (Syllabics)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CTR",
-            "locale": "crh_x_ctr",
-            "vernacular": "Қрим-тотор",
-            "script": "ROMAN",
-            "name": "Crimean Tatar",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CTC",
-            "locale": "crh_x_ctc",
-            "vernacular": "къырымтатар (кирилл)",
-            "script": "CYRILLIC",
-            "name": "Crimean Tatar (Cyrillic)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HZJ",
-            "locale": "csq",
-            "vernacular": "hrvatski znakovni jezik",
-            "script": "ROMAN",
-            "name": "Croatian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "CBS",
-            "locale": "csf",
-            "vernacular": "lengua de señas cubana",
-            "script": "ROMAN",
-            "name": "Cuban Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "CBE",
-            "locale": "cub",
-            "vernacular": "Cubeo",
-            "script": "ROMAN",
-            "name": "Cubeo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CPC",
-            "locale": "kpc",
-            "vernacular": "Curripaco",
-            "script": "ROMAN",
-            "name": "Curripaco",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "B",
-            "locale": "cs",
-            "vernacular": "čeština",
-            "script": "ROMAN",
-            "name": "Czech",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CSE",
-            "locale": "cse",
-            "vernacular": "český znakový jazyk",
-            "script": "ROMAN",
-            "name": "Czech Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "DGA",
-            "locale": "dga",
-            "vernacular": "Dagaare",
-            "script": "ROMAN",
-            "name": "Dagaare",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DGB",
-            "locale": "dag",
-            "vernacular": "Dagbanli",
-            "script": "ROMAN",
-            "name": "Dagbani",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DT",
-            "locale": "dak",
-            "vernacular": "Dakota",
-            "script": "ROMAN",
-            "name": "Dakota",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DMR",
-            "locale": "naq_x_dmr",
-            "vernacular": "Damara",
-            "script": "ROMAN",
-            "name": "Damara",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DG",
-            "locale": "ada",
-            "vernacular": "Dangme",
-            "script": "ROMAN",
-            "name": "Dangme",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "D",
-            "locale": "da",
-            "vernacular": "Dansk",
-            "script": "ROMAN",
-            "name": "Danish",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DSL",
-            "locale": "dsl",
-            "vernacular": "Dansk tegnsprog",
-            "script": "ROMAN",
-            "name": "Danish Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "DRG",
-            "locale": "dar",
-            "vernacular": "дарган",
-            "script": "CYRILLIC",
-            "name": "Dargwa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DAR",
-            "locale": "prs",
-            "vernacular": "دری",
-            "script": "ARABIC",
-            "name": "Dari",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "DKA",
-            "locale": "knx",
-            "vernacular": "Dayak Ahe",
-            "script": "ROMAN",
-            "name": "Dayak Ahe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DK",
-            "locale": "nij",
-            "vernacular": "Dayak Ngaju",
-            "script": "ROMAN",
-            "name": "Dayak Ngaju",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DKS",
-            "locale": "sya",
-            "vernacular": "Dayak Siang",
-            "script": "ROMAN",
-            "name": "Dayak Siang",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DYT",
-            "locale": "xdy",
-            "vernacular": "Dayak Tomun",
-            "script": "ROMAN",
-            "name": "Dayak Tomun",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DND",
-            "locale": "ddn",
-            "vernacular": "Dendi",
-            "script": "ROMAN",
-            "name": "Dendi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DNS",
-            "locale": "dez",
-            "vernacular": "Londengese",
-            "script": "ROMAN",
-            "name": "Dengese",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DDL",
-            "locale": "dic",
-            "vernacular": "Dida (Lakota)",
-            "script": "ROMAN",
-            "name": "Dida (Lakota)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DGR",
-            "locale": "os_x_dgr",
-            "vernacular": "дигорон",
-            "script": "CYRILLIC",
-            "name": "Digor",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DI",
-            "locale": "din",
-            "vernacular": "Dinka",
-            "script": "ROMAN",
-            "name": "Dinka",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DO",
-            "locale": "dyo",
-            "vernacular": "Jóola",
-            "script": "ROMAN",
-            "name": "Diola",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DTM",
-            "locale": "tbz",
-            "vernacular": "Ditammari",
-            "script": "ROMAN",
-            "name": "Ditammari",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DTS",
-            "locale": "dts",
-            "vernacular": "Dɔgɔn (Tɔrɔ Sɔ)",
-            "script": "ROMAN",
-            "name": "Dogon (Toro So)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DA",
-            "locale": "dua",
-            "vernacular": "Douala",
-            "script": "ROMAN",
-            "name": "Douala",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LF",
-            "locale": "dhv",
-            "vernacular": "Drehu",
-            "script": "ROMAN",
-            "name": "Drehu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DGN",
-            "locale": "dng",
-            "vernacular": "Dungan",
-            "script": "CYRILLIC",
-            "name": "Dungan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KAD",
-            "locale": "dtp",
-            "vernacular": "Dusun",
-            "script": "ROMAN",
-            "name": "Dusun",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OBG",
-            "locale": "nl_be",
-            "vernacular": "Nederlands (België)",
-            "script": "ROMAN",
-            "name": "Dutch (Belgium)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OSR",
-            "locale": "nl_sr",
-            "vernacular": "Nederlands (Suriname)",
-            "script": "ROMAN",
-            "name": "Dutch (Suriname)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NGT",
-            "locale": "dse",
-            "vernacular": "Nederlandse Gebarentaal",
-            "script": "ROMAN",
-            "name": "Dutch Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "DZR",
-            "locale": "dzo_latn",
-            "vernacular": "Dzongkha (Roman)",
-            "script": "ROMAN",
-            "name": "Dzongkha (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DZ",
-            "locale": "dzo_tibt",
-            "vernacular": "Dzongkha (Tibetan)",
-            "script": "TIBETAN",
-            "name": "Dzongkha (Tibetan)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "EBA",
-            "locale": "igb",
-            "vernacular": "Ebira",
-            "script": "ROMAN",
-            "name": "Ebira",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SEC",
-            "locale": "ecs",
-            "vernacular": "lengua de señas ecuatoriana",
-            "script": "ROMAN",
-            "name": "Ecuadorian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "ED",
-            "locale": "bin",
-            "vernacular": "Edo",
-            "script": "ROMAN",
-            "name": "Edo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "EFN",
-            "locale": "llp",
-            "vernacular": "Efate (North)",
-            "script": "ROMAN",
-            "name": "Efate (North)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "EFS",
-            "locale": "erk",
-            "vernacular": "Efate (South)",
-            "script": "ROMAN",
-            "name": "Efate (South)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "EF",
-            "locale": "efi",
-            "vernacular": "Efịk",
-            "script": "ROMAN",
-            "name": "Efik",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "EMB",
-            "locale": "cto",
-            "vernacular": "embera katio",
-            "script": "ROMAN",
-            "name": "Emberá (Catío)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "EMC",
-            "locale": "cmi",
-            "vernacular": "ẽbẽra beɗea chamí",
-            "script": "ROMAN",
-            "name": "Emberá (Chamí)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "EMP",
-            "locale": "emp",
-            "vernacular": "Emberá dóbida",
-            "script": "ROMAN",
-            "name": "Emberá (Northern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ENG",
-            "locale": "en_ng",
-            "vernacular": "English (Nigeria)",
-            "script": "ROMAN",
-            "name": "English (Nigeria)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "EZ",
-            "locale": "myv",
-            "vernacular": "эрзянь",
-            "script": "CYRILLIC",
-            "name": "Erzya",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IH",
-            "locale": "ish",
-            "vernacular": "Esan",
-            "script": "ROMAN",
-            "name": "Esan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ST",
-            "locale": "et",
-            "vernacular": "eesti",
-            "script": "ROMAN",
-            "name": "Estonian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "STD",
-            "locale": "eso",
-            "vernacular": "eesti viipekeel",
-            "script": "ROMAN",
-            "name": "Estonian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "ESL",
-            "locale": "eth",
-            "vernacular": "የኢትዮጵያ ምልክት ቋንቋ",
-            "script": "ETHIOPIC",
-            "name": "Ethiopian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "ETN",
-            "locale": "eto",
-            "vernacular": "Iton",
-            "script": "ROMAN",
-            "name": "Eton",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "EW",
-            "locale": "ee",
-            "vernacular": "Eʋegbe",
-            "script": "ROMAN",
-            "name": "Ewe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "EWN",
-            "locale": "ewo",
-            "vernacular": "Ewondo",
-            "script": "ROMAN",
-            "name": "Ewondo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FGN",
-            "locale": "fan",
-            "vernacular": "Fang",
-            "script": "ROMAN",
-            "name": "Fang",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FA",
-            "locale": "fat",
-            "vernacular": "Mfantse",
-            "script": "ROMAN",
-            "name": "Fante",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FR",
-            "locale": "fo",
-            "vernacular": "Føroyskt",
-            "script": "ROMAN",
-            "name": "Faroese",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FTL",
-            "locale": "ddg",
-            "vernacular": "Fataluku",
-            "script": "ROMAN",
-            "name": "Fataluku",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FFE",
-            "locale": "fmp",
-            "vernacular": "Bafang",
-            "script": "ROMAN",
-            "name": "Fe'fe'",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FJS",
-            "locale": "sgn_fj",
-            "vernacular": "Fiji Sign Language",
-            "script": "ROMAN",
-            "name": "Fiji Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "FN",
-            "locale": "fj",
-            "vernacular": "vakaViti",
-            "script": "ROMAN",
-            "name": "Fijian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FSL",
-            "locale": "psp",
-            "vernacular": "Filipino Sign Language",
-            "script": "ROMAN",
-            "name": "Filipino Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "FID",
-            "locale": "fse",
-            "vernacular": "suomalainen viittomakieli",
-            "script": "ROMAN",
-            "name": "Finnish Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "VGT",
-            "locale": "vgt",
-            "vernacular": "Vlaamse Gebarentaal",
-            "script": "ROMAN",
-            "name": "Flemish Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "FO",
-            "locale": "fon",
-            "vernacular": "Fɔngbe",
-            "script": "ROMAN",
-            "name": "Fon",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FF",
-            "locale": "gur",
-            "vernacular": "Farefare",
-            "script": "ROMAN",
-            "name": "Frafra",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FCD",
-            "locale": "fr_cl",
-            "vernacular": "Français Ivoirien",
-            "script": "ROMAN",
-            "name": "Français Ivoirien",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FBN",
-            "locale": "fr_bj",
-            "vernacular": "Français (Bénin)",
-            "script": "ROMAN",
-            "name": "French (Benin)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FCA",
-            "locale": "fr_ca",
-            "vernacular": "Français (Canada)",
-            "script": "ROMAN",
-            "name": "French (Canada)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSF",
-            "locale": "fsl",
-            "vernacular": "Langue des signes française",
-            "script": "ROMAN",
-            "name": "French Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "FS",
-            "locale": "fy",
-            "vernacular": "Frysk",
-            "script": "ROMAN",
-            "name": "Frisian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FD",
-            "locale": "fub",
-            "vernacular": "Fulfulde (Kamerun)",
-            "script": "ROMAN",
-            "name": "Fulfulde (Cameroon)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FLN",
-            "locale": "fuv",
-            "vernacular": "Fulfulde (Nigerian)",
-            "script": "ROMAN",
-            "name": "Fulfulde (Nigerian)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FT",
-            "locale": "fud",
-            "vernacular": "Fakafutuna",
-            "script": "ROMAN",
-            "name": "Futuna (East)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FW",
-            "locale": "fwa",
-            "vernacular": "Fwâi",
-            "script": "ROMAN",
-            "name": "Fwâi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GA",
-            "locale": "gaa",
-            "vernacular": "Ga",
-            "script": "ROMAN",
-            "name": "Ga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GZ",
-            "locale": "gag_x_gz",
-            "vernacular": "гaгaуз",
-            "script": "CYRILLIC",
-            "name": "Gagauz",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GZR",
-            "locale": "gag_x_gzr",
-            "vernacular": "gagauz (latin)",
-            "script": "ROMAN",
-            "name": "Gagauz (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GLC",
-            "locale": "gl",
-            "vernacular": "Galego",
-            "script": "ROMAN",
-            "name": "Galician",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GRW",
-            "locale": "gbm",
-            "vernacular": "गढ़वाली",
-            "script": "DEVANAGARI",
-            "name": "Garhwali",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GRF",
-            "locale": "cab",
-            "vernacular": "Garifuna",
-            "script": "ROMAN",
-            "name": "Garifuna",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GAR",
-            "locale": "grt_x_gar",
-            "vernacular": "গারো (আবেং)",
-            "script": "BENGALI",
-            "name": "Garo (Abeng)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GBA",
-            "locale": "gba",
-            "vernacular": "Gbaya",
-            "script": "ROMAN",
-            "name": "Gbaya",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GDE",
-            "locale": "jw_gde",
-            "vernacular": "Gede'uffa",
-            "script": "ROMAN",
-            "name": "Gedeo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GE",
-            "locale": "ka",
-            "vernacular": "ქართული",
-            "script": "GEORGIAN",
-            "name": "Georgian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GGS",
-            "locale": "sgn_ge",
-            "vernacular": "ქართული ჟესტური ენა",
-            "script": "GEORGIAN",
-            "name": "Georgian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "DGS",
-            "locale": "gsg",
-            "vernacular": "Deutsche Gebärdensprache",
-            "script": "ROMAN",
-            "name": "German Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "GHS",
-            "locale": "gse",
-            "vernacular": "Ghanaian Sign Language",
-            "script": "ROMAN",
-            "name": "Ghanaian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "GHM",
-            "locale": "bbj",
-            "vernacular": "Bandjoun-Baham",
-            "script": "ROMAN",
-            "name": "Ghomálá’",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GY",
-            "locale": "nyf",
-            "vernacular": "Giryama",
-            "script": "ROMAN",
-            "name": "Giryama",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GTN",
-            "locale": "toh",
-            "vernacular": "Gitonga",
-            "script": "ROMAN",
-            "name": "Gitonga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GG",
-            "locale": "gog",
-            "vernacular": "Cigogo",
-            "script": "ROMAN",
-            "name": "Gogo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GN",
-            "locale": "gkn",
-            "vernacular": "Gokana",
-            "script": "ROMAN",
-            "name": "Gokana",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GRC",
-            "locale": "gux",
-            "vernacular": "Gulmancema",
-            "script": "ROMAN",
-            "name": "Gourmanchéma",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GO",
-            "locale": "goa",
-            "vernacular": "Goro",
-            "script": "ROMAN",
-            "name": "Gouro",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GRB",
-            "locale": "grb",
-            "vernacular": "Grebo",
-            "script": "ROMAN",
-            "name": "Grebo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "G",
-            "locale": "el",
-            "vernacular": "Ελληνική",
-            "script": "GREEK",
-            "name": "Greek",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GSL",
-            "locale": "gss",
-            "vernacular": "Ελληνική Νοηματική Γλώσσα",
-            "script": "GREEK",
-            "name": "Greek Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "GL",
-            "locale": "kl",
-            "vernacular": "Kalaallisut",
-            "script": "ROMAN",
-            "name": "Greenlandic",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GLE",
-            "locale": "kl_x_gle",
-            "vernacular": "Tunumiisut",
-            "script": "ROMAN",
-            "name": "Greenlandic (East)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GCR",
-            "locale": "gcf",
-            "vernacular": "Kréyòl Gwadloup",
-            "script": "ROMAN",
-            "name": "Guadeloupean Creole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GHB",
-            "locale": "guh",
-            "vernacular": "guahibo",
-            "script": "ROMAN",
-            "name": "Guahibo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GBM",
-            "locale": "gum",
-            "vernacular": "Namtrik",
-            "script": "ROMAN",
-            "name": "Guambiano",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GI",
-            "locale": "gug",
-            "vernacular": "guarani",
-            "script": "ROMAN",
-            "name": "Guarani",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GIB",
-            "locale": "gui",
-            "vernacular": "Guaraní boliviano",
-            "script": "ROMAN",
-            "name": "Guarani (Bolivia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GIM",
-            "locale": "gun",
-            "vernacular": "Guaraní (Mbyá)",
-            "script": "ROMAN",
-            "name": "Guaraní (Mbyá)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GRY",
-            "locale": "gyr",
-            "vernacular": "Guarayu",
-            "script": "ROMAN",
-            "name": "Guarayu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSG",
-            "locale": "gsm",
-            "vernacular": "lengua de señas de Guatemala",
-            "script": "ROMAN",
-            "name": "Guatemalan Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "GBR",
-            "locale": "guo",
-            "vernacular": "jiw",
-            "script": "ROMAN",
-            "name": "Guayabero",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GRZ",
-            "locale": "gkp",
-            "vernacular": "Kpɛlɛɛwoo",
-            "script": "ROMAN",
-            "name": "Guerze",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GNC",
-            "locale": "gcr",
-            "vernacular": "Kréyòl gwiyanè",
-            "script": "ROMAN",
-            "name": "Guianese Creole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GU",
-            "locale": "gu",
-            "vernacular": "ગુજરાતી",
-            "script": "GUJARATI",
-            "name": "Gujarati",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "EG",
-            "locale": "guw",
-            "vernacular": "Gungbe",
-            "script": "ROMAN",
-            "name": "Gun",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "UN",
-            "locale": "cuk",
-            "vernacular": "dule",
-            "script": "ROMAN",
-            "name": "Guna",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GCE",
-            "locale": "gyn",
-            "vernacular": "Guyanese Creole English",
-            "script": "ROMAN",
-            "name": "Guyanese Creole English",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GUR",
-            "locale": "gxx",
-            "vernacular": "wɛ",
-            "script": "ROMAN",
-            "name": "Guéré",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HDY",
-            "locale": "hdy",
-            "vernacular": "Hadiyya",
-            "script": "ROMAN",
-            "name": "Hadiyya",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CR",
-            "locale": "ht",
-            "vernacular": "Kreyòl ayisyen",
-            "script": "ROMAN",
-            "name": "Haitian Creole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HKI",
-            "locale": "hak_id",
-            "vernacular": "Cina Khek (Indonesia)",
-            "script": "ROMAN",
-            "name": "Hakka (Indonesia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CHH",
-            "locale": "hak",
-            "vernacular": "客家話（台灣）",
-            "script": "CHINESE",
-            "name": "Hakka (Taiwan)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HLA",
-            "locale": "hla",
-            "vernacular": "Halia",
-            "script": "ROMAN",
-            "name": "Halia",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HMA",
-            "locale": "hyw_x_hma",
-            "vernacular": "համշեներեն (հայերեն)",
-            "script": "ARMENIAN",
-            "name": "Hamshen (Armenian)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HMS",
-            "locale": "hyw_x_hms",
-            "vernacular": "һамшенерен (кирилица)",
-            "script": "CYRILLIC",
-            "name": "Hamshen (Cyrillic)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HNO",
-            "locale": "lml",
-            "vernacular": "Hano",
-            "script": "ROMAN",
-            "name": "Hano",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HRV",
-            "locale": "bgc",
-            "vernacular": "हरियाण्वी",
-            "script": "DEVANAGARI",
-            "name": "Haryanvi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HA",
-            "locale": "ha",
-            "vernacular": "Hausa",
-            "script": "ROMAN",
-            "name": "Hausa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HVU",
-            "locale": "hav",
-            "vernacular": "Ekihavu",
-            "script": "ROMAN",
-            "name": "Havu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HW",
-            "locale": "haw",
-            "vernacular": "ʻŌlelo Hawaiʻi",
-            "script": "ROMAN",
-            "name": "Hawaiian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HWP",
-            "locale": "hwc",
-            "vernacular": "Hawai’i Pidgin",
-            "script": "ROMAN",
-            "name": "Hawai’i Pidgin",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HWU",
-            "locale": "hvn",
-            "vernacular": "Sabu",
-            "script": "ROMAN",
-            "name": "Hawu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HY",
-            "locale": "hay",
-            "vernacular": "Ekihaya",
-            "script": "ROMAN",
-            "name": "Haya",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "Q",
-            "locale": "he",
-            "vernacular": "עברית",
-            "script": "HEBREW",
-            "name": "Hebrew",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "HH",
-            "locale": "heh",
-            "vernacular": "Kihehe",
-            "script": "ROMAN",
-            "name": "Hehe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HR",
-            "locale": "hz",
-            "vernacular": "Otjiherero",
-            "script": "ROMAN",
-            "name": "Herero",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HV",
-            "locale": "hil",
-            "vernacular": "Hiligaynon",
-            "script": "ROMAN",
-            "name": "Hiligaynon",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HI",
-            "locale": "hi",
-            "vernacular": "हिंदी",
-            "script": "DEVANAGARI",
-            "name": "Hindi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HFJ",
-            "locale": "hif",
-            "vernacular": "Hindi (Fiji)",
-            "script": "ROMAN",
-            "name": "Hindi (Fiji)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HRM",
-            "locale": "hi_latn",
-            "vernacular": "Hindi (Roman)",
-            "script": "ROMAN",
-            "name": "Hindi (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MO",
-            "locale": "ho",
-            "vernacular": "Hiri Motu",
-            "script": "ROMAN",
-            "name": "Hiri Motu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MCG",
-            "locale": "mbn",
-            "vernacular": "Jitnu",
-            "script": "ROMAN",
-            "name": "Hitnu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HMN",
-            "locale": "hnj",
-            "vernacular": "Moob Ntsuab",
-            "script": "ROMAN",
-            "name": "Hmong (Green)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HM",
-            "locale": "hmn",
-            "vernacular": "Hmoob Dawb",
-            "script": "ROMAN",
-            "name": "Hmong (White)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SHO",
-            "locale": "hds",
-            "vernacular": "lengua de señas hondureña",
-            "script": "ROMAN",
-            "name": "Honduras Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "HSL",
-            "locale": "hks",
-            "vernacular": "香港手語",
-            "script": "CHINESE",
-            "name": "Hong Kong Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "HPI",
-            "locale": "hop",
-            "vernacular": "Hopi",
-            "script": "ROMAN",
-            "name": "Hopi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HST",
-            "locale": "hus",
-            "vernacular": "tének",
-            "script": "ROMAN",
-            "name": "Huastec (San Luis Potosi)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HSV",
-            "locale": "hus_x_hsv",
-            "vernacular": "tének de Veracruz",
-            "script": "ROMAN",
-            "name": "Huastec (Veracruz)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HUV",
-            "locale": "huv",
-            "vernacular": "ombeayiiüts",
-            "script": "ROMAN",
-            "name": "Huave (San Mateo del Mar)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HU",
-            "locale": "hul",
-            "vernacular": "Vula’a",
-            "script": "ROMAN",
-            "name": "Hula",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "H",
-            "locale": "hu",
-            "vernacular": "magyar",
-            "script": "ROMAN",
-            "name": "Hungarian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HDF",
-            "locale": "hsh",
-            "vernacular": "magyar jelnyelv",
-            "script": "ROMAN",
-            "name": "Hungarian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "HSK",
-            "locale": "hrx",
-            "vernacular": "Hunsrik",
-            "script": "ROMAN",
-            "name": "Hunsrik",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HTX",
-            "locale": "geh",
-            "vernacular": "Hutterite German",
-            "script": "ROMAN",
-            "name": "Hutterite German",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IAA",
-            "locale": "iai",
-            "vernacular": "Iaai",
-            "script": "ROMAN",
-            "name": "Iaai",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IBL",
-            "locale": "ibl",
-            "vernacular": "Ibaloi",
-            "script": "ROMAN",
-            "name": "Ibaloi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IA",
-            "locale": "iba",
-            "vernacular": "Iban",
-            "script": "ROMAN",
-            "name": "Iban",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IG",
-            "locale": "ibg",
-            "vernacular": "Ibanag",
-            "script": "ROMAN",
-            "name": "Ibanag",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IBI",
-            "locale": "yom_x_ibi",
-            "vernacular": "Ibinda",
-            "script": "ROMAN",
-            "name": "Ibinda",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IC",
-            "locale": "is",
-            "vernacular": "íslenska",
-            "script": "ROMAN",
-            "name": "Icelandic",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ID",
-            "locale": "idu",
-            "vernacular": "Idoma",
-            "script": "ROMAN",
-            "name": "Idoma",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AA",
-            "locale": "igl",
-            "vernacular": "Igala",
-            "script": "ROMAN",
-            "name": "Igala",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IB",
-            "locale": "ig",
-            "vernacular": "Igbo",
-            "script": "ROMAN",
-            "name": "Igbo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IGE",
-            "locale": "ige",
-            "vernacular": "Igede",
-            "script": "ROMAN",
-            "name": "Igede",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IGN",
-            "locale": "ign",
-            "vernacular": "Ignaciano",
-            "script": "ROMAN",
-            "name": "Ignaciano",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IJ",
-            "locale": "ijc",
-            "vernacular": "Ijaw",
-            "script": "ROMAN",
-            "name": "Ijaw",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IL",
-            "locale": "ilo",
-            "vernacular": "Iloko",
-            "script": "ROMAN",
-            "name": "Iloko",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IKN",
-            "locale": "akl",
-            "vernacular": "Inakeanon",
-            "script": "ROMAN",
-            "name": "Inakeanon",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "INS",
-            "locale": "ins",
-            "vernacular": "Indian Sign Language",
-            "script": "ROMAN",
-            "name": "Indian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "IN",
-            "locale": "id",
-            "vernacular": "Indonesia",
-            "script": "ROMAN",
-            "name": "Indonesian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "INI",
-            "locale": "inl",
-            "vernacular": "Bahasa Isyarat Indonesia",
-            "script": "ROMAN",
-            "name": "Indonesian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "INB",
-            "locale": "inb",
-            "vernacular": "Inga",
-            "script": "ROMAN",
-            "name": "Inga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IUR",
-            "locale": "iu_latn",
-            "vernacular": "Inuktitut",
-            "script": "ROMAN",
-            "name": "Inuktitut (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IU",
-            "locale": "iu",
-            "vernacular": "ᐃᓄᒃᑎᑐᑦ (ᖃᓂᐅᔮᖅᐸᐃᑦ)",
-            "script": "CANADIAN_SY",
-            "name": "Inuktitut (Syllabics)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GC",
-            "locale": "ga",
-            "vernacular": "Gaeilge",
-            "script": "ROMAN",
-            "name": "Irish",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ISG",
-            "locale": "isg",
-            "vernacular": "Irish Sign Language",
-            "script": "ROMAN",
-            "name": "Irish Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "CRE",
-            "locale": "icr",
-            "vernacular": "San Andrés Creole",
-            "script": "ROMAN",
-            "name": "Islander Creole English",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IS",
-            "locale": "iso",
-            "vernacular": "Isoko",
-            "script": "ROMAN",
-            "name": "Isoko",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QSL",
-            "locale": "isr",
-            "vernacular": "שפת סימנים ישראלית",
-            "script": "HEBREW",
-            "name": "Israeli Sign Language",
-            "isSignLanguage": true,
-            "isRTL": true
-        },
-        {
-            "code": "I",
-            "locale": "it",
-            "vernacular": "Italiano",
-            "script": "ROMAN",
-            "name": "Italian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ISL",
-            "locale": "ise",
-            "vernacular": "Lingua dei segni italiana",
-            "script": "ROMAN",
-            "name": "Italian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "ITW",
-            "locale": "itv",
-            "vernacular": "Itawit",
-            "script": "ROMAN",
-            "name": "Itawit",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IT",
-            "locale": "its",
-            "vernacular": "Itsekiri",
-            "script": "ROMAN",
-            "name": "Itsekiri",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "IMN",
-            "locale": "ium",
-            "vernacular": "Iu-Mienh",
-            "script": "ROMAN",
-            "name": "Iu Mien",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSI",
-            "locale": "sgn_ci",
-            "vernacular": "Langue des signes ivoirienne",
-            "script": "ROMAN",
-            "name": "Ivorian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "IXL",
-            "locale": "ixl",
-            "vernacular": "ixil",
-            "script": "ROMAN",
-            "name": "Ixil",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "JCR",
-            "locale": "jam_x_jcr",
-            "vernacular": "Patwa",
-            "script": "ROMAN",
-            "name": "Jamaican Creole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "JML",
-            "locale": "jls",
-            "vernacular": "Jamaican Sign Language",
-            "script": "ROMAN",
-            "name": "Jamaican Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "J",
-            "locale": "ja",
-            "vernacular": "日本語",
-            "script": "JAPANESE",
-            "name": "Japanese",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "JSL",
-            "locale": "jsl",
-            "vernacular": "日本手話",
-            "script": "JAPANESE",
-            "name": "Japanese Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "JAR",
-            "locale": "jra",
-            "vernacular": "Jarai",
-            "script": "ROMAN",
-            "name": "Jarai",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "JA",
-            "locale": "jv",
-            "vernacular": "Jawa",
-            "script": "ROMAN",
-            "name": "Javanese",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "JVN",
-            "locale": "jav",
-            "vernacular": "Jawa Timur",
-            "script": "ROMAN",
-            "name": "Javanese (Eastern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "JJU",
-            "locale": "jje",
-            "vernacular": "제주어",
-            "script": "KOREAN",
-            "name": "Jejueo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "JWK",
-            "locale": "whg",
-            "vernacular": "Jiwaka Yu",
-            "script": "ROMAN",
-            "name": "Jiwaka",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "JL",
-            "locale": "dyu",
-            "vernacular": "Jula",
-            "script": "ROMAN",
-            "name": "Jula",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KBR",
-            "locale": "kbd",
-            "vernacular": "адыгэбзэ",
-            "script": "CYRILLIC",
-            "name": "Kabardin-Cherkess",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KAB",
-            "locale": "kbp",
-            "vernacular": "Kabɩyɛ",
-            "script": "ROMAN",
-            "name": "Kabiye",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KBV",
-            "locale": "kea",
-            "vernacular": "Kabuverdianu",
-            "script": "ROMAN",
-            "name": "Kabuverdianu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KBT",
-            "locale": "kea_x_kbt",
-            "vernacular": "Kabuverdianu (Barlaventu)",
-            "script": "ROMAN",
-            "name": "Kabuverdianu (Barlaventu)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KBY",
-            "locale": "kab",
-            "vernacular": "Taqbaylit",
-            "script": "ROMAN",
-            "name": "Kabyle",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AH",
-            "locale": "kac",
-            "vernacular": "Kachin",
-            "script": "ROMAN",
-            "name": "Kachin",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KDV",
-            "locale": "fij_x_kdv",
-            "vernacular": "Kadavu",
-            "script": "ROMAN",
-            "name": "Kadavu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KAZ",
-            "locale": "kzj",
-            "vernacular": "Kadazan",
-            "script": "ROMAN",
-            "name": "Kadazan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KGG",
-            "locale": "kgp",
-            "vernacular": "kaingang",
-            "script": "ROMAN",
-            "name": "Kaingang",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KAA",
-            "locale": "kgk",
-            "vernacular": "Kaiwá",
-            "script": "ROMAN",
-            "name": "Kaiwá",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KL",
-            "locale": "kck_x_kl",
-            "vernacular": "Kalanga (Botswana)",
-            "script": "ROMAN",
-            "name": "Kalanga (Botswana)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KLZ",
-            "locale": "kck_x_klz",
-            "vernacular": "Kalanga (Zimbabwe)",
-            "script": "ROMAN",
-            "name": "Kalanga (Zimbabwe)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KJ",
-            "locale": "kln",
-            "vernacular": "Kalenjin",
-            "script": "ROMAN",
-            "name": "Kalenjin",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KLK",
-            "locale": "xal",
-            "vernacular": "хальмг",
-            "script": "CYRILLIC",
-            "name": "Kalmyk",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KMY",
-            "locale": "kyk",
-            "vernacular": "Kamayo",
-            "script": "ROMAN",
-            "name": "Kamayo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KB",
-            "locale": "kam",
-            "vernacular": "Kikamba",
-            "script": "ROMAN",
-            "name": "Kamba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KMB",
-            "locale": "xbr",
-            "vernacular": "Kambera (Sumba Timur)",
-            "script": "ROMAN",
-            "name": "Kambera",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KMW",
-            "locale": "hig",
-            "vernacular": "Kamwe",
-            "script": "ROMAN",
-            "name": "Kamwe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KGH",
-            "locale": "xnr",
-            "vernacular": "कंगड़ी (हमीरपुरी)",
-            "script": "DEVANAGARI",
-            "name": "Kangri (Hamirpuri)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KNY",
-            "locale": "kne",
-            "vernacular": "Kankanaey",
-            "script": "ROMAN",
-            "name": "Kankanaey",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KA",
-            "locale": "kn",
-            "vernacular": "ಕನ್ನಡ",
-            "script": "KANNADA",
-            "name": "Kannada",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KYK",
-            "locale": "kny",
-            "vernacular": "Ciin-kanyok",
-            "script": "ROMAN",
-            "name": "Kanyok",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BAL",
-            "locale": "krc",
-            "vernacular": "къарачай-малкъар",
-            "script": "CYRILLIC",
-            "name": "Karachay-Balkar",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KRK",
-            "locale": "kaa",
-            "vernacular": "қарақалпақ",
-            "script": "CYRILLIC",
-            "name": "Karakalpak",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KPN",
-            "locale": "pww",
-            "vernacular": "โผล่ง",
-            "script": "THAI",
-            "name": "Karen (Pwo Northern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PK",
-            "locale": "pwo",
-            "vernacular": "Karen (Pwo Western)",
-            "script": "MYANMAR",
-            "name": "Karen (Pwo Western)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KR",
-            "locale": "ksw",
-            "vernacular": "ကညီ(စှီၤ)ကျိာ်",
-            "script": "MYANMAR",
-            "name": "Karen (S'gaw)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KSM",
-            "locale": "xsm",
-            "vernacular": "Kasem",
-            "script": "ROMAN",
-            "name": "Kasem",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KSH",
-            "locale": "csb",
-            "vernacular": "kaszëbsczi",
-            "script": "ROMAN",
-            "name": "Kashubian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AZ",
-            "locale": "kk",
-            "vernacular": "қазақ",
-            "script": "CYRILLIC",
-            "name": "Kazakh",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AZA",
-            "locale": "kk_arab",
-            "vernacular": "قازاق ٴتىلى (ارابشا جازۋى)",
-            "script": "ARABIC",
-            "name": "Kazakh (Arabic)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "KEI",
-            "locale": "kei",
-            "vernacular": "Kei",
-            "script": "ROMAN",
-            "name": "Kei",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GK",
-            "locale": "kek",
-            "vernacular": "q’eqchi’",
-            "script": "ROMAN",
-            "name": "Kekchi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KSI",
-            "locale": "xki",
-            "vernacular": "Kenyan Sign Language",
-            "script": "ROMAN",
-            "name": "Kenyan Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "KHK",
-            "locale": "kjh",
-            "vernacular": "хакас",
-            "script": "CYRILLIC",
-            "name": "Khakass",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OG",
-            "locale": "ogo",
-            "vernacular": "Khana",
-            "script": "ROMAN",
-            "name": "Khana",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KHL",
-            "locale": "hin_x_khl",
-            "vernacular": "Khari Boli",
-            "script": "ROMAN",
-            "name": "Khari Boli",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KS",
-            "locale": "kha",
-            "vernacular": "Khasi",
-            "script": "ROMAN",
-            "name": "Khasi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KMN",
-            "locale": "kxm",
-            "vernacular": "ขแมร์เสียม",
-            "script": "THAI",
-            "name": "Khmer (Northern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KBL",
-            "locale": "blv",
-            "vernacular": "Kibala",
-            "script": "ROMAN",
-            "name": "Kibala",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KFL",
-            "locale": "flr",
-            "vernacular": "Kifuliiru",
-            "script": "ROMAN",
-            "name": "Kifuliiru",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KHB",
-            "locale": "hem",
-            "vernacular": "Kihemba",
-            "script": "ROMAN",
-            "name": "Kihemba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KD",
-            "locale": "kqn",
-            "vernacular": "Kikaonde",
-            "script": "ROMAN",
-            "name": "Kikaonde",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KG",
-            "locale": "kwy",
-            "vernacular": "Kikongo",
-            "script": "ROMAN",
-            "name": "Kikongo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KGL",
-            "locale": "ktu_x_kgl",
-            "vernacular": "Kikongo ya leta",
-            "script": "ROMAN",
-            "name": "Kikongo ya Leta",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KQ",
-            "locale": "ki",
-            "vernacular": "Gĩkũyũ",
-            "script": "ROMAN",
-            "name": "Kikuyu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KU",
-            "locale": "lu",
-            "vernacular": "Kiluba",
-            "script": "ROMAN",
-            "name": "Kiluba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MNN",
-            "locale": "kg_x_mnn",
-            "vernacular": "Kimanianga",
-            "script": "ROMAN",
-            "name": "Kimanyanga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KIM",
-            "locale": "kmb",
-            "vernacular": "Kimbundu",
-            "script": "ROMAN",
-            "name": "Kimbundu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KIN",
-            "locale": "nnb",
-            "vernacular": "Kinande",
-            "script": "ROMAN",
-            "name": "Kinande",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KNR",
-            "locale": "krj",
-            "vernacular": "Kinaray-a",
-            "script": "ROMAN",
-            "name": "Kinaray-a",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KK",
-            "locale": "nyy_x_kk",
-            "vernacular": "Kinyakyusa",
-            "script": "ROMAN",
-            "name": "Kinyakyusa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YW",
-            "locale": "rw",
-            "vernacular": "Ikinyarwanda",
-            "script": "ROMAN",
-            "name": "Kinyarwanda",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KIP",
-            "locale": "pem",
-            "vernacular": "Kipende",
-            "script": "ROMAN",
-            "name": "Kipende",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KZ",
-            "locale": "ky",
-            "vernacular": "кыргыз",
-            "script": "CYRILLIC",
-            "name": "Kirghiz",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GB",
-            "locale": "gil",
-            "vernacular": "Kiribati",
-            "script": "ROMAN",
-            "name": "Kiribati",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RU",
-            "locale": "run",
-            "vernacular": "Ikirundi",
-            "script": "ROMAN",
-            "name": "Kirundi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KI",
-            "locale": "kss",
-            "vernacular": "Kisiei",
-            "script": "ROMAN",
-            "name": "Kisi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "II",
-            "locale": "guz",
-            "vernacular": "Kisii",
-            "script": "ROMAN",
-            "name": "Kisii",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KSN",
-            "locale": "sop",
-            "vernacular": "Kisongye",
-            "script": "ROMAN",
-            "name": "Kisonge",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KIT",
-            "locale": "ktu_x_kit",
-            "vernacular": "Kituba",
-            "script": "ROMAN",
-            "name": "Kituba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KBK",
-            "locale": "trp",
-            "vernacular": "Kokborok",
-            "script": "ROMAN",
-            "name": "Kokborok",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KKL",
-            "locale": "kzn",
-            "vernacular": "Kokola",
-            "script": "ROMAN",
-            "name": "Kokola",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KM",
-            "locale": "kpv",
-            "vernacular": "коми",
-            "script": "CYRILLIC",
-            "name": "Komi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KMP",
-            "locale": "koi",
-            "vernacular": "коми-пермяцкӧй",
-            "script": "CYRILLIC",
-            "name": "Komi-Permyak",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MK",
-            "locale": "kg",
-            "vernacular": "Kikongo (Rép. dém. du congo)",
-            "script": "ROMAN",
-            "name": "Kongo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KND",
-            "locale": "kex",
-            "vernacular": "कोंकणी (देवनागरी)",
-            "script": "DEVANAGARI",
-            "name": "Konkani (Devanagari)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KN",
-            "locale": "knn",
-            "vernacular": "ಕೊಂಕಣಿ (ಕನ್ನಡ)",
-            "script": "KANNADA",
-            "name": "Konkani (Kannada)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KT",
-            "locale": "gom",
-            "vernacular": "Konkani (Romi)",
-            "script": "ROMAN",
-            "name": "Konkani (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KKB",
-            "locale": "xon",
-            "vernacular": "Konkomba",
-            "script": "ROMAN",
-            "name": "Konkomba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KNO",
-            "locale": "kno",
-            "vernacular": "Kono",
-            "script": "ROMAN",
-            "name": "Kono",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KOC",
-            "locale": "ko_cn",
-            "vernacular": "조선어",
-            "script": "KOREAN",
-            "name": "Korean (China)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KSL",
-            "locale": "kvk",
-            "vernacular": "한국 수어",
-            "script": "KOREAN",
-            "name": "Korean Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "OS",
-            "locale": "kos",
-            "vernacular": "Kosraean",
-            "script": "ROMAN",
-            "name": "Kosraean",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KTI",
-            "locale": "eko",
-            "vernacular": "Koti",
-            "script": "ROMAN",
-            "name": "Koti",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KP",
-            "locale": "xpe",
-            "vernacular": "Kpelle",
-            "script": "ROMAN",
-            "name": "Kpelle",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KRI",
-            "locale": "kri",
-            "vernacular": "Krio",
-            "script": "ROMAN",
-            "name": "Krio",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KRY",
-            "locale": "tt_x_kry",
-            "vernacular": "керәшен татар",
-            "script": "CYRILLIC",
-            "name": "Kryashen",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KUA",
-            "locale": "ksd",
-            "vernacular": "Tinata Tuna",
-            "script": "ROMAN",
-            "name": "Kuanua",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KHN",
-            "locale": "sbs",
-            "vernacular": "Kuhane (Subiya)",
-            "script": "ROMAN",
-            "name": "Kuhane (Subiya)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KUI",
-            "locale": "uki",
-            "vernacular": "Kui",
-            "script": "ROMAN",
-            "name": "Kui",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KNM",
-            "locale": "kun",
-            "vernacular": "Kunama",
-            "script": "ROMAN",
-            "name": "Kunama",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KDA",
-            "locale": "kdn",
-            "vernacular": "Kunda",
-            "script": "ROMAN",
-            "name": "Kunda",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RD",
-            "locale": "kmr_x_rd",
-            "vernacular": "Kurdî (Kurmancî)",
-            "script": "ROMAN",
-            "name": "Kurdish Kurmanji",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RDU",
-            "locale": "kmr_x_rdu",
-            "vernacular": "Kurdî Kurmancî (Kavkazûs)",
-            "script": "ROMAN",
-            "name": "Kurdish Kurmanji (Caucasus)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RDC",
-            "locale": "kmr_cyrl",
-            "vernacular": "К′öрди Кöрманщи (Кирили)",
-            "script": "CYRILLIC",
-            "name": "Kurdish Kurmanji (Cyrillic)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RDA",
-            "locale": "ckb",
-            "vernacular": "کوردی سۆرانی",
-            "script": "ARABIC",
-            "name": "Kurdish Sorani",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "KUR",
-            "locale": "kuj",
-            "vernacular": "Igikuria",
-            "script": "ROMAN",
-            "name": "Kuria",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KRH",
-            "locale": "kru",
-            "vernacular": "Kurukh",
-            "script": "ROMAN",
-            "name": "Kurukh",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KUS",
-            "locale": "kus",
-            "vernacular": "Kusaal",
-            "script": "ROMAN",
-            "name": "Kusaal",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KCC",
-            "locale": "kfr",
-            "vernacular": "કચ્છી",
-            "script": "GUJARATI",
-            "name": "Kutchi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KVM",
-            "locale": "olu",
-            "vernacular": "Kuvale (Mucubal)",
-            "script": "ROMAN",
-            "name": "Kuvale (Mucubal)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KUY",
-            "locale": "kdt",
-            "vernacular": "Kuy",
-            "script": "THAI",
-            "name": "Kuy",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WG",
-            "locale": "kwn",
-            "vernacular": "Rukwangali",
-            "script": "ROMAN",
-            "name": "Kwangali",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KY",
-            "locale": "kj",
-            "vernacular": "Oshikwanyama",
-            "script": "ROMAN",
-            "name": "Kwanyama",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KW",
-            "locale": "kwf",
-            "vernacular": "Kwara'ae",
-            "script": "ROMAN",
-            "name": "Kwara'ae",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KWS",
-            "locale": "nmg",
-            "vernacular": "Kwasio",
-            "script": "ROMAN",
-            "name": "Kwasio",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NKN",
-            "locale": "nyy_x_nkn",
-            "vernacular": "Kyangonde",
-            "script": "ROMAN",
-            "name": "Kyangonde",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LAD",
-            "locale": "lld_x_lad",
-            "vernacular": "Ladin de Gherdëina",
-            "script": "ROMAN",
-            "name": "Ladin (Gardenese)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LAH",
-            "locale": "lhu",
-            "vernacular": "Laˇhuˍ hkawˇ",
-            "script": "ROMAN",
-            "name": "Lahu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LKT",
-            "locale": "lkt",
-            "vernacular": "Lakotiya",
-            "script": "ROMAN",
-            "name": "Lakota",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AB",
-            "locale": "lam",
-            "vernacular": "Lamba",
-            "script": "ROMAN",
-            "name": "Lamba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LMD",
-            "locale": "lmn",
-            "vernacular": "Lambadi",
-            "script": "ROMAN",
-            "name": "Lambadi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LMB",
-            "locale": "lai",
-            "vernacular": "Chilambya",
-            "script": "ROMAN",
-            "name": "Lambya",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LN",
-            "locale": "laj",
-            "vernacular": "lango",
-            "script": "ROMAN",
-            "name": "Lango",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CML",
-            "locale": "sgn_cm",
-            "vernacular": "Langue des signes camerounaise",
-            "script": "ROMAN",
-            "name": "Langue des signes camerounaise",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "LA",
-            "locale": "lo",
-            "vernacular": "ລາວ",
-            "script": "LAOTIAN",
-            "name": "Laotian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LR",
-            "locale": "ldi",
-            "vernacular": "Kilari",
-            "script": "ROMAN",
-            "name": "Lari",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LTG",
-            "locale": "ltg",
-            "vernacular": "Latgalīšu",
-            "script": "ROMAN",
-            "name": "Latgalian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LT",
-            "locale": "lv",
-            "vernacular": "latviešu",
-            "script": "ROMAN",
-            "name": "Latvian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSL",
-            "locale": "lsl",
-            "vernacular": "latviešu zīmju valoda",
-            "script": "ROMAN",
-            "name": "Latvian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "LNN",
-            "locale": "llx",
-            "vernacular": "Lauan",
-            "script": "ROMAN",
-            "name": "Lauan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LBS",
-            "locale": "sgn_lb",
-            "vernacular": "لغة الإشارات اللبنانية",
-            "script": "ARABIC",
-            "name": "Lebanese Sign Language",
-            "isSignLanguage": true,
-            "isRTL": true
-        },
-        {
-            "code": "LGA",
-            "locale": "lea",
-            "vernacular": "Lega",
-            "script": "ROMAN",
-            "name": "Lega",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LL",
-            "locale": "lln",
-            "vernacular": "Lele",
-            "script": "ROMAN",
-            "name": "Lele",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LNK",
-            "locale": "tnl",
-            "vernacular": "Lenakel",
-            "script": "ROMAN",
-            "name": "Lenakel",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LND",
-            "locale": "led",
-            "vernacular": "Baledha",
-            "script": "ROMAN",
-            "name": "Lendu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LJ",
-            "locale": "leh",
-            "vernacular": "Cilenje",
-            "script": "ROMAN",
-            "name": "Lenje",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LZ",
-            "locale": "lez",
-            "vernacular": "лезги",
-            "script": "CYRILLIC",
-            "name": "Lezgian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LHK",
-            "locale": "koo",
-            "vernacular": "Lhukonzo",
-            "script": "ROMAN",
-            "name": "Lhukonzo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ELI",
-            "locale": "lir",
-            "vernacular": "Liberian English",
-            "script": "ROMAN",
-            "name": "Liberian English",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LWC",
-            "locale": "lia",
-            "vernacular": "Limba (West-Central)",
-            "script": "ROMAN",
-            "name": "Limba (West-Central)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LBM",
-            "locale": "lmp",
-            "vernacular": "Limbum",
-            "script": "ROMAN",
-            "name": "Limbum",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LI",
-            "locale": "ln",
-            "vernacular": "Lingala",
-            "script": "ROMAN",
-            "name": "Lingala",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LIS",
-            "locale": "lis",
-            "vernacular": "ꓡꓲ-ꓢꓴ",
-            "script": "LISU",
-            "name": "Lisu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "L",
-            "locale": "lt",
-            "vernacular": "lietuvių",
-            "script": "ROMAN",
-            "name": "Lithuanian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LTS",
-            "locale": "lls",
-            "vernacular": "lietuvių gestų",
-            "script": "ROMAN",
-            "name": "Lithuanian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "LKA",
-            "locale": "yaz",
-            "vernacular": "Lokaa",
-            "script": "ROMAN",
-            "name": "Lokaa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LLO",
-            "locale": "llb",
-            "vernacular": "Ilolo",
-            "script": "ROMAN",
-            "name": "Lolo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OM",
-            "locale": "lom",
-            "vernacular": "Lɔɔma",
-            "script": "ROMAN",
-            "name": "Loma",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LOM",
-            "locale": "lol",
-            "vernacular": "Lɔmɔngɔ",
-            "script": "ROMAN",
-            "name": "Lomongo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LE",
-            "locale": "ngl",
-            "vernacular": "Elomwe",
-            "script": "ROMAN",
-            "name": "Lomwe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LGD",
-            "locale": "lnu",
-            "vernacular": "Longuda",
-            "script": "ROMAN",
-            "name": "Longuda",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LWX",
-            "locale": "pdt",
-            "vernacular": "Plautdietsch",
-            "script": "ROMAN",
-            "name": "Low German",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LC",
-            "locale": "lch",
-            "vernacular": "Luchazi",
-            "script": "ROMAN",
-            "name": "Luchazi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LU",
-            "locale": "lg",
-            "vernacular": "Luganda",
-            "script": "ROMAN",
-            "name": "Luganda",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LG",
-            "locale": "lgg",
-            "vernacular": "Lugbara",
-            "script": "ROMAN",
-            "name": "Lugbara",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LD",
-            "locale": "lun",
-            "vernacular": "Lunda",
-            "script": "ROMAN",
-            "name": "Lunda",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LO",
-            "locale": "luo",
-            "vernacular": "Dholuo",
-            "script": "ROMAN",
-            "name": "Luo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LV",
-            "locale": "lue",
-            "vernacular": "Luvale",
-            "script": "ROMAN",
-            "name": "Luvale",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LX",
-            "locale": "lb",
-            "vernacular": "Lëtzebuergesch",
-            "script": "ROMAN",
-            "name": "Luxembourgish",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MS",
-            "locale": "mas",
-            "vernacular": "Maasai",
-            "script": "ROMAN",
-            "name": "Maasai",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MC",
-            "locale": "mk",
-            "vernacular": "македонски",
-            "script": "CYRILLIC",
-            "name": "Macedonian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MAC",
-            "locale": "vmw",
-            "vernacular": "Emakhuwa",
-            "script": "ROMAN",
-            "name": "Macua",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MCT",
-            "locale": "fij_x_mct",
-            "vernacular": "Macuata",
-            "script": "ROMAN",
-            "name": "Macuata",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MCS",
-            "locale": "mbc",
-            "vernacular": "Makusi",
-            "script": "ROMAN",
-            "name": "Macushi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TTM",
-            "locale": "mzc",
-            "vernacular": "Tenin’ny Tanana Malagasy",
-            "script": "ROMAN",
-            "name": "Madagascar Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "MDI",
-            "locale": "mhi",
-            "vernacular": "Madi",
-            "script": "ROMAN",
-            "name": "Madi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MDR",
-            "locale": "mad",
-            "vernacular": "Madura",
-            "script": "ROMAN",
-            "name": "Madura",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MAF",
-            "locale": "maf",
-            "vernacular": "Mafa",
-            "script": "ROMAN",
-            "name": "Mafa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MU",
-            "locale": "mdh",
-            "vernacular": "Maguindanao",
-            "script": "ROMAN",
-            "name": "Maguindanao",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ORR",
-            "locale": "swb_x_orr",
-            "vernacular": "Shimaore (Alifuɓe)",
-            "script": "ROMAN",
-            "name": "Mahorian (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MHL",
-            "locale": "mai",
-            "vernacular": "मैथिली",
-            "script": "DEVANAGARI",
-            "name": "Maithili",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MKA",
-            "locale": "mcp",
-            "vernacular": "Makaa",
-            "script": "ROMAN",
-            "name": "Makaa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MKS",
-            "locale": "mkz_x_mks",
-            "vernacular": "Makasae",
-            "script": "ROMAN",
-            "name": "Makasae",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MHM",
-            "locale": "xmc",
-            "vernacular": "Makhuwa-Marrevone",
-            "script": "ROMAN",
-            "name": "Makhuwa-Marrevone",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MWM",
-            "locale": "mgh",
-            "vernacular": "Imakhuwa Imeetto",
-            "script": "ROMAN",
-            "name": "Makhuwa-Meetto",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MKM",
-            "locale": "mhm",
-            "vernacular": "Makhuwa-Moniga",
-            "script": "ROMAN",
-            "name": "Makhuwa-Moniga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MHS",
-            "locale": "vmk",
-            "vernacular": "Makhuwa-Shirima",
-            "script": "ROMAN",
-            "name": "Makhuwa-Shirima",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MKD",
-            "locale": "kde",
-            "vernacular": "Shimakonde",
-            "script": "ROMAN",
-            "name": "Makonde",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MG",
-            "locale": "mg",
-            "vernacular": "Malagasy",
-            "script": "ROMAN",
-            "name": "Malagasy",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MSL",
-            "locale": "sgn_mw",
-            "vernacular": "Chinenero Chamanja cha ku Malawi",
-            "script": "ROMAN",
-            "name": "Malawi Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "ML",
-            "locale": "ms",
-            "vernacular": "Melayu",
-            "script": "ROMAN",
-            "name": "Malay",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MPN",
-            "locale": "pmy",
-            "vernacular": "Malay (Papuan)",
-            "script": "ROMAN",
-            "name": "Malay (Papuan)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MY",
-            "locale": "ml",
-            "vernacular": "മലയാളം",
-            "script": "MALAYALAM",
-            "name": "Malayalam",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MLY",
-            "locale": "mbp",
-            "vernacular": "wiwa dumuna",
-            "script": "ROMAN",
-            "name": "Malayo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BIM",
-            "locale": "xml",
-            "vernacular": "Bahasa Isyarat Malaysia",
-            "script": "ROMAN",
-            "name": "Malaysian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "MT",
-            "locale": "mt",
-            "vernacular": "Malti",
-            "script": "ROMAN",
-            "name": "Maltese",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MLS",
-            "locale": "mdl",
-            "vernacular": "Lingwa tas-Sinjali Maltija",
-            "script": "ROMAN",
-            "name": "Maltese Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "MZ",
-            "locale": "mam",
-            "vernacular": "mam",
-            "script": "ROMAN",
-            "name": "Mam",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AMA",
-            "locale": "mqj",
-            "vernacular": "Mamasa",
-            "script": "ROMAN",
-            "name": "Mamasa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MME",
-            "locale": "mgm_x_mme",
-            "vernacular": "Mambae (Ermera)",
-            "script": "ROMAN",
-            "name": "Mambae (Ermera)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MWL",
-            "locale": "mgr",
-            "vernacular": "Cimambwe-Lungu",
-            "script": "ROMAN",
-            "name": "Mambwe-Lungu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MNM",
-            "locale": "xmm",
-            "vernacular": "Manado",
-            "script": "ROMAN",
-            "name": "Manado Malay",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MDL",
-            "locale": "mjl",
-            "vernacular": "Mandeali",
-            "script": "ROMAN",
-            "name": "Mandeali",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MNK",
-            "locale": "mnk",
-            "vernacular": "Mandinka",
-            "script": "ROMAN",
-            "name": "Mandinka",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MNJ",
-            "locale": "mzv",
-            "vernacular": "Mandja",
-            "script": "ROMAN",
-            "name": "Mandja",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MJK",
-            "locale": "mfv",
-            "vernacular": "Manjaku",
-            "script": "ROMAN",
-            "name": "Mandjak",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MGR",
-            "locale": "mrv",
-            "vernacular": "Mangareva",
-            "script": "ROMAN",
-            "name": "Mangareva",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MKE",
-            "locale": "emk",
-            "vernacular": "Mandingo",
-            "script": "ROMAN",
-            "name": "Maninkakan (Eastern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MI",
-            "locale": "mni",
-            "vernacular": "মৈতৈলোন্",
-            "script": "BENGALI",
-            "name": "Manipuri",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MIR",
-            "locale": "mni_latn",
-            "vernacular": "Manipuri (Roman)",
-            "script": "ROMAN",
-            "name": "Manipuri (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MNO",
-            "locale": "mev",
-            "vernacular": "Maa",
-            "script": "ROMAN",
-            "name": "Mano",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MNI",
-            "locale": "mns",
-            "vernacular": "маньси",
-            "script": "CYRILLIC",
-            "name": "Mansi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MYW",
-            "locale": "mny",
-            "vernacular": "Emanyawa",
-            "script": "ROMAN",
-            "name": "Manyawa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MA",
-            "locale": "mi",
-            "vernacular": "Te Reo Māori",
-            "script": "ROMAN",
-            "name": "Maori",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MPD",
-            "locale": "arn",
-            "vernacular": "mapudungun",
-            "script": "ROMAN",
-            "name": "Mapudungun",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MQR",
-            "locale": "mch",
-            "vernacular": "Ye’kuana",
-            "script": "ROMAN",
-            "name": "Maquiritari",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OL",
-            "locale": "rag",
-            "vernacular": "Luragooli",
-            "script": "ROMAN",
-            "name": "Maragoli",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MR",
-            "locale": "mr",
-            "vernacular": "मराठी",
-            "script": "DEVANAGARI",
-            "name": "Marathi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MAR",
-            "locale": "mhr",
-            "vernacular": "марий",
-            "script": "CYRILLIC",
-            "name": "Mari",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MRH",
-            "locale": "mrj",
-            "vernacular": "кырык мары",
-            "script": "CYRILLIC",
-            "name": "Mari (Hill)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MQN",
-            "locale": "mrq",
-            "vernacular": "Marquisien (Nuku Hiva)",
-            "script": "ROMAN",
-            "name": "Marquesian (Nuku Hiva)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MH",
-            "locale": "mh",
-            "vernacular": "Kajin M̦ajel̦",
-            "script": "ROMAN",
-            "name": "Marshallese",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MTC",
-            "locale": "gcf_x_mtc",
-            "vernacular": "Kréyol Matinik",
-            "script": "ROMAN",
-            "name": "Martiniquan Creole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MRW",
-            "locale": "rwr",
-            "vernacular": "Marwari",
-            "script": "ROMAN",
-            "name": "Marwari",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MSH",
-            "locale": "shr",
-            "vernacular": "Mashi",
-            "script": "ROMAN",
-            "name": "Mashi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MTN",
-            "locale": "mgv",
-            "vernacular": "Kimatengo",
-            "script": "ROMAN",
-            "name": "Matengo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MSS",
-            "locale": "mcf",
-            "vernacular": "Matses",
-            "script": "ROMAN",
-            "name": "Matses",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CE",
-            "locale": "mfe",
-            "vernacular": "Kreol Morisien",
-            "script": "ROMAN",
-            "name": "Mauritian Creole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MTS",
-            "locale": "lsy",
-            "vernacular": "Mauritian Sign Language",
-            "script": "ROMAN",
-            "name": "Mauritian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "MAY",
-            "locale": "yua",
-            "vernacular": "maaya",
-            "script": "ROMAN",
-            "name": "Maya",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MAP",
-            "locale": "mop",
-            "vernacular": "T'an",
-            "script": "ROMAN",
-            "name": "Maya (Mopán)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MYG",
-            "locale": "yan",
-            "vernacular": "mayangna",
-            "script": "ROMAN",
-            "name": "Mayangna",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MYO",
-            "locale": "mfy",
-            "vernacular": "yoremnok'ki",
-            "script": "ROMAN",
-            "name": "Mayo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MZH",
-            "locale": "maz",
-            "vernacular": "jñatrjo",
-            "script": "ROMAN",
-            "name": "Mazahua",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MAZ",
-            "locale": "mau",
-            "vernacular": "énná",
-            "script": "ROMAN",
-            "name": "Mazatec (Huautla)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MBL",
-            "locale": "mdp",
-            "vernacular": "Gimbala",
-            "script": "ROMAN",
-            "name": "Mbala",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MBN",
-            "locale": "mxg",
-            "vernacular": "Mbangala",
-            "script": "ROMAN",
-            "name": "Mbangala",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MBO",
-            "locale": "mbo",
-            "vernacular": "Mbo",
-            "script": "ROMAN",
-            "name": "Mbo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MBK",
-            "locale": "mhw",
-            "vernacular": "Thimbukushu",
-            "script": "ROMAN",
-            "name": "Mbukushu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MMU",
-            "locale": "mdd",
-            "vernacular": "Mbum",
-            "script": "ROMAN",
-            "name": "Mbum",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MBD",
-            "locale": "mck",
-            "vernacular": "Mbunda",
-            "script": "ROMAN",
-            "name": "Mbunda",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MDH",
-            "locale": "nan_x_mdh",
-            "vernacular": "Hokkien Medan",
-            "script": "ROMAN",
-            "name": "Medan Hokkien",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DU",
-            "locale": "byv",
-            "vernacular": "Bangangté",
-            "script": "ROMAN",
-            "name": "Medumba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MNS",
-            "locale": "sgn_pg",
-            "vernacular": "Melanesian Sign Language",
-            "script": "ROMAN",
-            "name": "Melanesian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "ME",
-            "locale": "men",
-            "vernacular": "Mɛnde",
-            "script": "ROMAN",
-            "name": "Mende",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MGK",
-            "locale": "xmg",
-            "vernacular": "Mengaka",
-            "script": "ROMAN",
-            "name": "Mengaka",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MWI",
-            "locale": "mwv",
-            "vernacular": "Mentawai",
-            "script": "ROMAN",
-            "name": "Mentawai",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "UU",
-            "locale": "mer",
-            "vernacular": "Kĩmĩĩrũ",
-            "script": "ROMAN",
-            "name": "Meru",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MTA",
-            "locale": "mgo",
-            "vernacular": "Meta'",
-            "script": "ROMAN",
-            "name": "Meta'",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MWR",
-            "locale": "mtr",
-            "vernacular": "Mewari",
-            "script": "ROMAN",
-            "name": "Mewari",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSM",
-            "locale": "mfs",
-            "vernacular": "lengua de señas mexicana",
-            "script": "ROMAN",
-            "name": "Mexican Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "CHN",
-            "locale": "nan_x_chn",
-            "vernacular": "闽南语（泉州）",
-            "script": "CHINESE",
-            "name": "Min Nan (Quanzhou)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CHW",
-            "locale": "nan_x_chw",
-            "vernacular": "閩南語（台灣）",
-            "script": "CHINESE",
-            "name": "Min Nan (Taiwan)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MGL",
-            "locale": "xmf",
-            "vernacular": "მარგალური",
-            "script": "GEORGIAN",
-            "name": "Mingrelian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MIS",
-            "locale": "miq",
-            "vernacular": "miskitu",
-            "script": "ROMAN",
-            "name": "Miskito",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MX",
-            "locale": "mco",
-            "vernacular": "ayuk",
-            "script": "ROMAN",
-            "name": "Mixe (North Central)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MXC",
-            "locale": "mio",
-            "vernacular": "saʼan xiñi saví",
-            "script": "ROMAN",
-            "name": "Mixtec (Costa)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MXG",
-            "locale": "mxv",
-            "vernacular": "tu’un sâví",
-            "script": "ROMAN",
-            "name": "Mixtec (Guerrero)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MXO",
-            "locale": "jmx",
-            "vernacular": "Tu̱ʼun ndaʼví",
-            "script": "ROMAN",
-            "name": "Mixtec (Huajuapan)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MXN",
-            "locale": "xtd",
-            "vernacular": "ñutnuu",
-            "script": "ROMAN",
-            "name": "Mixtec (Tilantongo)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MXT",
-            "locale": "meh",
-            "vernacular": "saʼan savi",
-            "script": "ROMAN",
-            "name": "Mixtec (Tlaxiaco)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LS",
-            "locale": "lus",
-            "vernacular": "Mizo",
-            "script": "ROMAN",
-            "name": "Mizo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MKQ",
-            "locale": "mic",
-            "vernacular": "Mi'kmaw",
-            "script": "ROMAN",
-            "name": "Mi’kmaq",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MNC",
-            "locale": "cmo",
-            "vernacular": "Bunong",
-            "script": "ROMAN",
-            "name": "Mnong (Central)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MBA",
-            "locale": "mfq",
-            "vernacular": "Muaba",
-            "script": "ROMAN",
-            "name": "Moba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MHK",
-            "locale": "moh",
-            "vernacular": "Kanienʼkéha",
-            "script": "ROMAN",
-            "name": "Mohawk",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MOK",
-            "locale": "mdf",
-            "vernacular": "мокшень",
-            "script": "CYRILLIC",
-            "name": "Moksha",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KHA",
-            "locale": "mn",
-            "vernacular": "монгол",
-            "script": "CYRILLIC",
-            "name": "Mongolian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KHC",
-            "locale": "mvf",
-            "vernacular": "Mongolian (Traditional)",
-            "script": "MONGOLIAN",
-            "name": "Mongolian (Traditional)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MSR",
-            "locale": "msr",
-            "vernacular": "монгол дохионы хэл",
-            "script": "CYRILLIC",
-            "name": "Mongolian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "MNT",
-            "locale": "cnr",
-            "vernacular": "crnogorski",
-            "script": "ROMAN",
-            "name": "Montenegrin",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MM",
-            "locale": "mos",
-            "vernacular": "Moore",
-            "script": "ROMAN",
-            "name": "Moore",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MTU",
-            "locale": "meu",
-            "vernacular": "Motu",
-            "script": "ROMAN",
-            "name": "Motu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OU",
-            "locale": "mua",
-            "vernacular": "Moundang",
-            "script": "ROMAN",
-            "name": "Moundang",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MOU",
-            "locale": "mse",
-            "vernacular": "Moussey",
-            "script": "ROMAN",
-            "name": "Moussey",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SLM",
-            "locale": "mzy",
-            "vernacular": "Língua de Sinais Moçambicana",
-            "script": "ROMAN",
-            "name": "Mozambican Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "MNR",
-            "locale": "unr",
-            "vernacular": "Mundari",
-            "script": "ROMAN",
-            "name": "Mundari",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BU",
-            "locale": "my",
-            "vernacular": "မြန်မာ",
-            "script": "MYANMAR",
-            "name": "Myanmar",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BUS",
-            "locale": "sgn_mm",
-            "vernacular": "မြန်မာ လက်သင်္ကေတပြဘာသာစကား",
-            "script": "MYANMAR",
-            "name": "Myanmar Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "NDI",
-            "locale": "fij_x_ndi",
-            "vernacular": "Nadi",
-            "script": "ROMAN",
-            "name": "Nadi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NDR",
-            "locale": "wyy_x_ndr",
-            "vernacular": "Nadroga",
-            "script": "ROMAN",
-            "name": "Nadroga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NGG",
-            "locale": "njm",
-            "vernacular": "Naga (Angami)",
-            "script": "ROMAN",
-            "name": "Naga (Angami)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NLM",
-            "locale": "njn",
-            "vernacular": "Naga (Liangmai)",
-            "script": "ROMAN",
-            "name": "Naga (Liangmai)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NGR",
-            "locale": "nbu",
-            "vernacular": "Naga (Rongmei)",
-            "script": "ROMAN",
-            "name": "Naga (Rongmei)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NGD",
-            "locale": "nag",
-            "vernacular": "Nagamese",
-            "script": "ROMAN",
-            "name": "Nagamese",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NHC",
-            "locale": "ncx",
-            "vernacular": "náhuatl del centro",
-            "script": "ROMAN",
-            "name": "Nahuatl (Central)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NHG",
-            "locale": "ngu",
-            "vernacular": "náhuatl de guerrero",
-            "script": "ROMAN",
-            "name": "Nahuatl (Guerrero)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NHH",
-            "locale": "nch",
-            "vernacular": "náhuatl de la huasteca",
-            "script": "ROMAN",
-            "name": "Nahuatl (Huasteca)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NHT",
-            "locale": "ncj",
-            "vernacular": "náhuatl del norte de Puebla",
-            "script": "ROMAN",
-            "name": "Nahuatl (Northern Puebla)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NHV",
-            "locale": "nhk",
-            "vernacular": "náhuatl de Veracruz",
-            "script": "ROMAN",
-            "name": "Nahuatl (Veracruz)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NA",
-            "locale": "naq_x_na",
-            "vernacular": "ǀApakhoen gowab",
-            "script": "ROMAN",
-            "name": "Nama",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NMK",
-            "locale": "nmk",
-            "vernacular": "Namakura",
-            "script": "ROMAN",
-            "name": "Namakura",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NB",
-            "locale": "nmq",
-            "vernacular": "Nambya",
-            "script": "ROMAN",
-            "name": "Nambya",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SLN",
-            "locale": "nbs",
-            "vernacular": "Namibian Sign Language",
-            "script": "ROMAN",
-            "name": "Namibian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "NNR",
-            "locale": "bwb",
-            "vernacular": "Namosi-Naitasiri-Serua",
-            "script": "ROMAN",
-            "name": "Namosi-Naitasiri-Serua",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NCW",
-            "locale": "ncb",
-            "vernacular": "Nancowry",
-            "script": "ROMAN",
-            "name": "Nancowry",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NV",
-            "locale": "nv",
-            "vernacular": "Diné Bizaad",
-            "script": "ROMAN",
-            "name": "Navajo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NDL",
-            "locale": "ndh",
-            "vernacular": "Ichindali",
-            "script": "ROMAN",
-            "name": "Ndali",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NDA",
-            "locale": "ndc",
-            "vernacular": "Cindau",
-            "script": "ROMAN",
-            "name": "Ndau",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NDW",
-            "locale": "ndc_x_ndw",
-            "vernacular": "Ndau (Western)",
-            "script": "ROMAN",
-            "name": "Ndau (Western)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NBL",
-            "locale": "nr",
-            "vernacular": "IsiNdebele",
-            "script": "ROMAN",
-            "name": "Ndebele",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NBZ",
-            "locale": "nd",
-            "vernacular": "Ndebele (Zimbabwe)",
-            "script": "ROMAN",
-            "name": "Ndebele (Zimbabwe)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OD",
-            "locale": "ng",
-            "vernacular": "Oshindonga",
-            "script": "ROMAN",
-            "name": "Ndonga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NNT",
-            "locale": "yrk",
-            "vernacular": "ненэцяʼ",
-            "script": "CYRILLIC",
-            "name": "Nenets",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RE",
-            "locale": "nen",
-            "vernacular": "Nengone",
-            "script": "ROMAN",
-            "name": "Nengone",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NP",
-            "locale": "ne",
-            "vernacular": "नेपाली",
-            "script": "DEVANAGARI",
-            "name": "Nepali",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NSL",
-            "locale": "nsp",
-            "vernacular": "नेपाली साङ्केतिक भाषा",
-            "script": "DEVANAGARI",
-            "name": "Nepali Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "NZS",
-            "locale": "nzs",
-            "vernacular": "New Zealand Sign Language",
-            "script": "ROMAN",
-            "name": "New Zealand Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "NW",
-            "locale": "new",
-            "vernacular": "नेवारी",
-            "script": "DEVANAGARI",
-            "name": "Newari",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NGB",
-            "locale": "gym",
-            "vernacular": "ngäbere",
-            "script": "ROMAN",
-            "name": "Ngabere",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NG",
-            "locale": "sba",
-            "vernacular": "Ngambay",
-            "script": "ROMAN",
-            "name": "Ngambaye",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NGL",
-            "locale": "nba",
-            "vernacular": "Ngangela",
-            "script": "ROMAN",
-            "name": "Ngangela",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NGK",
-            "locale": "nga",
-            "vernacular": "Ngbaka",
-            "script": "ROMAN",
-            "name": "Ngbaka",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NGN",
-            "locale": "ngb",
-            "vernacular": "Ngbandi (ya Nɔrdi)",
-            "script": "ROMAN",
-            "name": "Ngbandi (Northern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NMB",
-            "locale": "nnh",
-            "vernacular": "Ngiemboon",
-            "script": "ROMAN",
-            "name": "Ngiemboon",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NGM",
-            "locale": "pls",
-            "vernacular": "ngigua de San Marcos Tlacoyalco",
-            "script": "ROMAN",
-            "name": "Ngigua (San Marcos Tlacoyalco)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NML",
-            "locale": "nla",
-            "vernacular": "Babadjou",
-            "script": "ROMAN",
-            "name": "Ngombale",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NGU",
-            "locale": "yrl",
-            "vernacular": "Nheengatu",
-            "script": "ROMAN",
-            "name": "Nhengatu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NI",
-            "locale": "nia",
-            "vernacular": "Nias",
-            "script": "ROMAN",
-            "name": "Nias",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSN",
-            "locale": "ncs",
-            "vernacular": "lenguaje de señas nicaragüense",
-            "script": "ROMAN",
-            "name": "Nicaraguan Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "NC",
-            "locale": "caq",
-            "vernacular": "Nicobarese",
-            "script": "ROMAN",
-            "name": "Nicobarese",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NGP",
-            "locale": "pcm",
-            "vernacular": "Nigerian Pidgin",
-            "script": "ROMAN",
-            "name": "Nigerian Pidgin",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NNS",
-            "locale": "nsi",
-            "vernacular": "Nigerian Sign Language",
-            "script": "ROMAN",
-            "name": "Nigerian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "NN",
-            "locale": "niu",
-            "vernacular": "Faka-Niue",
-            "script": "ROMAN",
-            "name": "Niuean",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NVC",
-            "locale": "cag",
-            "vernacular": "nivaĉle",
-            "script": "ROMAN",
-            "name": "Nivaclé",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NJB",
-            "locale": "nzb",
-            "vernacular": "Njebi",
-            "script": "ROMAN",
-            "name": "Njebi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NKY",
-            "locale": "nka",
-            "vernacular": "Nkoya",
-            "script": "ROMAN",
-            "name": "Nkoya",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NOR",
-            "locale": "ojb_x_nor",
-            "vernacular": "Anishinaabemowin",
-            "script": "ROMAN",
-            "name": "Northern Ojibwe (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NOS",
-            "locale": "ojb_x_nos",
-            "vernacular": "ᐊᓂᔑᓈᐯᒧᐎᓐ",
-            "script": "CANADIAN_SY",
-            "name": "Northern Ojibwe (Syllabics)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "N",
-            "locale": "no",
-            "vernacular": "Norsk",
-            "script": "ROMAN",
-            "name": "Norwegian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NDF",
-            "locale": "nsl",
-            "vernacular": "Norsk tegnspråk",
-            "script": "ROMAN",
-            "name": "Norwegian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "NSM",
-            "locale": "nse_mz",
-            "vernacular": "Chinsenga (Mozambique)",
-            "script": "ROMAN",
-            "name": "Nsenga (Mozambique)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NEN",
-            "locale": "nse",
-            "vernacular": "Cinsenga",
-            "script": "ROMAN",
-            "name": "Nsenga (Zambia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "UE",
-            "locale": "nus",
-            "vernacular": "Thok Nath",
-            "script": "ROMAN",
-            "name": "Nuer",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NKM",
-            "locale": "nuq",
-            "vernacular": "Nukumanu",
-            "script": "ROMAN",
-            "name": "Nukumanu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KWN",
-            "locale": "kdk",
-            "vernacular": "Kwényï",
-            "script": "ROMAN",
-            "name": "Numèè (Kwenyii)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YM",
-            "locale": "nym",
-            "vernacular": "Nyamwezi",
-            "script": "ROMAN",
-            "name": "Nyamwezi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NK",
-            "locale": "nyk",
-            "vernacular": "Nyaneka",
-            "script": "ROMAN",
-            "name": "Nyaneka",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NYL",
-            "locale": "yly",
-            "vernacular": "Nyelâyu",
-            "script": "ROMAN",
-            "name": "Nyelâyu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NY",
-            "locale": "nih",
-            "vernacular": "Nyiha",
-            "script": "ROMAN",
-            "name": "Nyiha",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NYU",
-            "locale": "nyu",
-            "vernacular": "Cinyungwe",
-            "script": "ROMAN",
-            "name": "Nyungwe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NZ",
-            "locale": "nzi",
-            "vernacular": "Nzema",
-            "script": "ROMAN",
-            "name": "Nzema",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OBL",
-            "locale": "ann",
-            "vernacular": "Obolo",
-            "script": "ROMAN",
-            "name": "Obolo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ODW",
-            "locale": "otw",
-            "vernacular": "Nishnaabemwin",
-            "script": "ROMAN",
-            "name": "Odawa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OI",
-            "locale": "or",
-            "vernacular": "ଓଡ଼ିଆ",
-            "script": "ORIYA",
-            "name": "Odia",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OKP",
-            "locale": "oke",
-            "vernacular": "Okpe",
-            "script": "ROMAN",
-            "name": "Okpe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LB",
-            "locale": "nyd",
-            "vernacular": "Olunyole",
-            "script": "ROMAN",
-            "name": "Olunyole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OMB",
-            "locale": "mbm",
-            "vernacular": "Ombamba",
-            "script": "ROMAN",
-            "name": "Ombamba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ORK",
-            "locale": "okv",
-            "vernacular": "Orokaiva",
-            "script": "ROMAN",
-            "name": "Orokaiva",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OA",
-            "locale": "om",
-            "vernacular": "Afaan Oromoo",
-            "script": "ROMAN",
-            "name": "Oromo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OSS",
-            "locale": "os",
-            "vernacular": "ирон",
-            "script": "CYRILLIC",
-            "name": "Ossetian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OSC",
-            "locale": "os_x_osc",
-            "vernacular": "Ирон (чысайнаг)",
-            "script": "CYRILLIC",
-            "name": "Ossetian (Chsan)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OSK",
-            "locale": "os_x_osk",
-            "vernacular": "Ирон (къуыдайраг)",
-            "script": "CYRILLIC",
-            "name": "Ossetian (Kudar)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OT",
-            "locale": "tll",
-            "vernacular": "Ɔtɛtɛla",
-            "script": "ROMAN",
-            "name": "Otetela",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OTE",
-            "locale": "otm",
-            "vernacular": "ñuhü",
-            "script": "ROMAN",
-            "name": "Otomi (Eastern Highland)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OTM",
-            "locale": "ote",
-            "vernacular": "Ñañu",
-            "script": "ROMAN",
-            "name": "Otomi (Mezquital Valley)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OTS",
-            "locale": "ots",
-            "vernacular": "ñätho",
-            "script": "ROMAN",
-            "name": "Otomi (State of Mexico)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PPG",
-            "locale": "ood",
-            "vernacular": "O’odham",
-            "script": "ROMAN",
-            "name": "O’odham (Tohono)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PAO",
-            "locale": "blk",
-            "vernacular": "Pa'o",
-            "script": "MYANMAR",
-            "name": "Pa'o",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PMA",
-            "locale": "pma",
-            "vernacular": "Paama",
-            "script": "ROMAN",
-            "name": "Paama",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PIC",
-            "locale": "pri",
-            "vernacular": "Paicî",
-            "script": "ROMAN",
-            "name": "Paicî",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PWN",
-            "locale": "pwn",
-            "vernacular": "Payuan",
-            "script": "ROMAN",
-            "name": "Paiwan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PU",
-            "locale": "pau",
-            "vernacular": "Palauan",
-            "script": "ROMAN",
-            "name": "Palauan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PLK",
-            "locale": "plu",
-            "vernacular": "Palikur",
-            "script": "ROMAN",
-            "name": "Palikúr",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PMO",
-            "locale": "pmf",
-            "vernacular": "Pamona",
-            "script": "ROMAN",
-            "name": "Pamona",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PSL",
-            "locale": "lsp",
-            "vernacular": "lengua de señas panameñas",
-            "script": "ROMAN",
-            "name": "Panamanian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "PN",
-            "locale": "pag",
-            "vernacular": "Pangasinan",
-            "script": "ROMAN",
-            "name": "Pangasinan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PPL",
-            "locale": "pbo",
-            "vernacular": "Oium",
-            "script": "ROMAN",
-            "name": "Papel",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PAA",
-            "locale": "pap_x_paa",
-            "vernacular": "Papiamento (Aruba)",
-            "script": "ROMAN",
-            "name": "Papiamento (Aruba)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PA",
-            "locale": "pap",
-            "vernacular": "Papiamentu (Kòrsou)",
-            "script": "ROMAN",
-            "name": "Papiamento (Curaçao)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSP",
-            "locale": "pys",
-            "vernacular": "lengua de señas paraguaya",
-            "script": "ROMAN",
-            "name": "Paraguayan Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "PH",
-            "locale": "ps",
-            "vernacular": "پښتو",
-            "script": "ARABIC",
-            "name": "Pashto",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "PHN",
-            "locale": "arn_x_phn",
-            "vernacular": "chedungun (pewenche)",
-            "script": "ROMAN",
-            "name": "Pehuenche",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PMN",
-            "locale": "aoc",
-            "vernacular": "pemon pe",
-            "script": "ROMAN",
-            "name": "Pemon",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "XPA",
-            "locale": "pdc",
-            "vernacular": "Pennsylvania Dutch (Deitsh)",
-            "script": "ROMAN",
-            "name": "Pennsylvania German",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PR",
-            "locale": "fa",
-            "vernacular": "فارسی",
-            "script": "ARABIC",
-            "name": "Persian",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "SPE",
-            "locale": "prl",
-            "vernacular": "lengua de señas peruana",
-            "script": "ROMAN",
-            "name": "Peruvian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "PHM",
-            "locale": "phm",
-            "vernacular": "Chiphimbi",
-            "script": "ROMAN",
-            "name": "Phimbi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SIH",
-            "locale": "pht",
-            "vernacular": "ภูไท",
-            "script": "THAI",
-            "name": "Phu Thai",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PRA",
-            "locale": "pid",
-            "vernacular": "huo̧ttö̧ja̧",
-            "script": "ROMAN",
-            "name": "Piaroa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PCM",
-            "locale": "wes",
-            "vernacular": "Pidgin for Cameroon",
-            "script": "ROMAN",
-            "name": "Pidgin (Cameroon)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PGW",
-            "locale": "wes_x_pgw",
-            "vernacular": "Pidgin (West Africa)",
-            "script": "ROMAN",
-            "name": "Pidgin (West Africa)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PLG",
-            "locale": "plg",
-            "vernacular": "pilagá",
-            "script": "ROMAN",
-            "name": "Pilagá",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PTJ",
-            "locale": "pjt",
-            "vernacular": "Pitjantjatjara",
-            "script": "ROMAN",
-            "name": "Pitjantjatjara",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PP",
-            "locale": "pon",
-            "vernacular": "Lokaiahn Pohnpei",
-            "script": "ROMAN",
-            "name": "Pohnpeian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "P",
-            "locale": "pl",
-            "vernacular": "polski",
-            "script": "ROMAN",
-            "name": "Polish",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PDF",
-            "locale": "pso",
-            "vernacular": "polski język migowy",
-            "script": "ROMAN",
-            "name": "Polish Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "PMR",
-            "locale": "nds",
-            "vernacular": "Pomerisch",
-            "script": "ROMAN",
-            "name": "Pomeranian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PPU",
-            "locale": "poi",
-            "vernacular": "popoluca de la Sierra",
-            "script": "ROMAN",
-            "name": "Popoluca (Highland)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "JC",
-            "locale": "jac_x_jc",
-            "vernacular": "poptí",
-            "script": "ROMAN",
-            "name": "Popti'",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PQM",
-            "locale": "poh",
-            "vernacular": "poqomchi'",
-            "script": "ROMAN",
-            "name": "Poqomchi'",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TNG",
-            "locale": "pt_ao",
-            "vernacular": "Português (Angola)",
-            "script": "ROMAN",
-            "name": "Portuguese (Angola)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "T",
-            "locale": "pt",
-            "vernacular": "Português (Brasil)",
-            "script": "ROMAN",
-            "name": "Portuguese (Brazil)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TMM",
-            "locale": "pt_mz",
-            "vernacular": "Português (Moçambique)",
-            "script": "ROMAN",
-            "name": "Portuguese (Mozambique)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LGP",
-            "locale": "psr",
-            "vernacular": "Língua Gestual Portuguesa",
-            "script": "ROMAN",
-            "name": "Portuguese Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "PLR",
-            "locale": "fuf",
-            "vernacular": "Fula",
-            "script": "ROMAN",
-            "name": "Pular",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PJ",
-            "locale": "pa",
-            "vernacular": "ਪੰਜਾਬੀ",
-            "script": "GURMUKHI",
-            "name": "Punjabi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PJN",
-            "locale": "pnb",
-            "vernacular": "پنجابی (شاہ مُکھی)",
-            "script": "URDU",
-            "name": "Punjabi (Shahmukhi)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "PUN",
-            "locale": "puu",
-            "vernacular": "Punu",
-            "script": "ROMAN",
-            "name": "Punu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PYM",
-            "locale": "pyu",
-            "vernacular": "Pinuyumayan",
-            "script": "ROMAN",
-            "name": "Puyuma",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "PAZ",
-            "locale": "pbb",
-            "vernacular": "nasa yuwe",
-            "script": "ROMAN",
-            "name": "Páez",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QNJ",
-            "locale": "kjb",
-            "vernacular": "q'anjob'al",
-            "script": "ROMAN",
-            "name": "Q'anjob'al",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSQ",
-            "locale": "fcs",
-            "vernacular": "Langue des signes québécoise",
-            "script": "ROMAN",
-            "name": "Quebec Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "QUN",
-            "locale": "que",
-            "vernacular": "Quechua (Ancash)",
-            "script": "ROMAN",
-            "name": "Quechua (Ancash)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QUA",
-            "locale": "quy",
-            "vernacular": "Quechua (Ayacucho)",
-            "script": "ROMAN",
-            "name": "Quechua (Ayacucho)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QUB",
-            "locale": "qu",
-            "vernacular": "Quechua (Bolivia)",
-            "script": "ROMAN",
-            "name": "Quechua (Bolivia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QU",
-            "locale": "quz",
-            "vernacular": "quechua (Cusco)",
-            "script": "ROMAN",
-            "name": "Quechua (Cuzco)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QUL",
-            "locale": "qub",
-            "vernacular": "Quechua de Huánuco (Huallaga)",
-            "script": "ROMAN",
-            "name": "Quechua (Huallaga Huánuco)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QUH",
-            "locale": "qvw",
-            "vernacular": "quechua wanca",
-            "script": "ROMAN",
-            "name": "Quechua (Huaylla Wanca)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QUM",
-            "locale": "quf",
-            "vernacular": "quechua (lambayeque)",
-            "script": "ROMAN",
-            "name": "Quechua (Lambayeque)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QC",
-            "locale": "quc",
-            "vernacular": "quiché",
-            "script": "ROMAN",
-            "name": "Quiche",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QCC",
-            "locale": "qxr",
-            "vernacular": "quichua (cañar)",
-            "script": "ROMAN",
-            "name": "Quichua (Cañar)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QIB",
-            "locale": "qu_x_qib",
-            "vernacular": "quichua (chibuleo)",
-            "script": "ROMAN",
-            "name": "Quichua (Chibuleo)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QIC",
-            "locale": "qug",
-            "vernacular": "quichua (chimborazo)",
-            "script": "ROMAN",
-            "name": "Quichua (Chimborazo)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QIX",
-            "locale": "qug_x_qix",
-            "vernacular": "quichua (cotopaxi)",
-            "script": "ROMAN",
-            "name": "Quichua (Cotopaxi)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QII",
-            "locale": "qvi",
-            "vernacular": "quichua (imbabura)",
-            "script": "ROMAN",
-            "name": "Quichua (Imbabura)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QIP",
-            "locale": "qvz",
-            "vernacular": "quichua (pastaza)",
-            "script": "ROMAN",
-            "name": "Quichua (Pastaza)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QCS",
-            "locale": "qu_x_qxl",
-            "vernacular": "quichua (salasaca)",
-            "script": "ROMAN",
-            "name": "Quichua (Salasaca)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QIS",
-            "locale": "qus",
-            "vernacular": "quichua (Santiago del Estero)",
-            "script": "ROMAN",
-            "name": "Quichua (Santiago del Estero)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "QIT",
-            "locale": "quw",
-            "vernacular": "quichua (tena)",
-            "script": "ROMAN",
-            "name": "Quichua (Tena)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "FNR",
-            "locale": "fij_x_fnr",
-            "vernacular": "Ra",
-            "script": "ROMAN",
-            "name": "Ra",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RPN",
-            "locale": "rap",
-            "vernacular": "rapa nui",
-            "script": "ROMAN",
-            "name": "Rapa Nui",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RA",
-            "locale": "rar",
-            "vernacular": "Reo Rarotonga",
-            "script": "ROMAN",
-            "name": "Rarotongan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "M",
-            "locale": "ro",
-            "vernacular": "Română",
-            "script": "ROMAN",
-            "name": "Romanian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RNN",
-            "locale": "ro_x_rnn",
-            "vernacular": "rumunski (vlaški)",
-            "script": "ROMAN",
-            "name": "Romanian (Vlach)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RNK",
-            "locale": "ro_x_rnk",
-            "vernacular": "rumunski (vlaški, Bačka)",
-            "script": "ROMAN",
-            "name": "Romanian (Vlach, Bačka)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LMG",
-            "locale": "rms",
-            "vernacular": "Limba semnelor române",
-            "script": "ROMAN",
-            "name": "Romanian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "RH",
-            "locale": "rm_x_rh",
-            "vernacular": "Rumantsch (Ladin)",
-            "script": "ROMAN",
-            "name": "Romansh (Ladin)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RHS",
-            "locale": "rm_x_rhs",
-            "vernacular": "romontsch (sursilvan)",
-            "script": "ROMAN",
-            "name": "Romansh (Sursilvan)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RML",
-            "locale": "rmy_al",
-            "vernacular": "rome (shqipëri)",
-            "script": "ROMAN",
-            "name": "Romany (Albania)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMA",
-            "locale": "rmy_ar",
-            "vernacular": "Romanes Kalderash",
-            "script": "ROMAN",
-            "name": "Romany (Argentina)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RRL",
-            "locale": "rmn_x_rrl",
-            "vernacular": "Romany (Arli)",
-            "script": "ROMAN",
-            "name": "Romany (Arli)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RBH",
-            "locale": "rmn_x_rbh",
-            "vernacular": "Romany (Bosnia and Herzegovina)",
-            "script": "ROMAN",
-            "name": "Romany (Bosnia and Herzegovina)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMY",
-            "locale": "rmn_x_rmy",
-            "vernacular": "ромски (централна България)",
-            "script": "ROMAN",
-            "name": "Romany (Central Bulgaria)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMH",
-            "locale": "rmy_cl",
-            "vernacular": "Romane Jorajane",
-            "script": "ROMAN",
-            "name": "Romany (Chile)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RNC",
-            "locale": "rmn_x_rnc",
-            "vernacular": "Романи (крымски)",
-            "script": "CYRILLIC",
-            "name": "Romany (Crimea)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMS",
-            "locale": "rmc_sk",
-            "vernacular": "romanes (vichodno Slovačiko)",
-            "script": "ROMAN",
-            "name": "Romany (Eastern Slovakia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMF",
-            "locale": "rmo_fr",
-            "vernacular": "Romanes (Manouche)",
-            "script": "ROMAN",
-            "name": "Romany (France)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMX",
-            "locale": "rmo",
-            "vernacular": "Romanes (Sinti)",
-            "script": "ROMAN",
-            "name": "Romany (Germany)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMK",
-            "locale": "rmy_x_rmk",
-            "vernacular": "хомани (котлярско, Хусыя)",
-            "script": "CYRILLIC",
-            "name": "Romany (Kalderash, Russia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RVK",
-            "locale": "rmy_x_rvk",
-            "vernacular": "Романі (ловарі, чокещі)",
-            "script": "CYRILLIC",
-            "name": "Romany (Lovari, Chokeshi)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LVA",
-            "locale": "rmy_x_lva",
-            "vernacular": "romani (lovári, Ungriko Them)",
-            "script": "ROMAN",
-            "name": "Romany (Lovari, Hungary)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RM",
-            "locale": "rmn_x_rm",
-            "vernacular": "romane (Makedonija)",
-            "script": "ROMAN",
-            "name": "Romany (Macedonia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMC",
-            "locale": "rmn_cyrl",
-            "vernacular": "романе (Македонија) кирилица",
-            "script": "CYRILLIC",
-            "name": "Romany (Macedonia) Cyrillic",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RCK",
-            "locale": "rmy_x_rck",
-            "vernacular": "Romany (Meçkar)",
-            "script": "ROMAN",
-            "name": "Romany (Meçkar)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RVC",
-            "locale": "rmy_x_rvc",
-            "vernacular": "Романи (Молдова) кирилик",
-            "script": "CYRILLIC",
-            "name": "Romany (Moldova) Cyrillic",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMN",
-            "locale": "rmn_x_rmn",
-            "vernacular": "Ρομανί (Βόρεια Ελλάδα)",
-            "script": "GREEK",
-            "name": "Romany (Northern Greece)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMP",
-            "locale": "rml_ru",
-            "vernacular": "романы (русска рома)",
-            "script": "CYRILLIC",
-            "name": "Romany (Northern Russia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMT",
-            "locale": "rml",
-            "vernacular": "romani (Polska Roma)",
-            "script": "ROMAN",
-            "name": "Romany (Poland)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMR",
-            "locale": "rmy",
-            "vernacular": "Rromani (România)",
-            "script": "ROMAN",
-            "name": "Romany (Romania)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RME",
-            "locale": "rmn_x_rme",
-            "vernacular": "Romane (Srbija)",
-            "script": "ROMAN",
-            "name": "Romany (Serbia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMG",
-            "locale": "rmn_x_rmg",
-            "vernacular": "Ρομανί (Νότια Ελλάδα)",
-            "script": "GREEK",
-            "name": "Romany (Southern Greece)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RSP",
-            "locale": "rmn_x_rsp",
-            "vernacular": "Romany (Spoitori)",
-            "script": "ROMAN",
-            "name": "Romany (Spoitori)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMU",
-            "locale": "rmy_ua",
-            "vernacular": "Романі (ромунгри, Україна)",
-            "script": "CYRILLIC",
-            "name": "Romany (Ukraine)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMV",
-            "locale": "rmy_x_rmv",
-            "vernacular": "романи (влахитско, Россия)",
-            "script": "CYRILLIC",
-            "name": "Romany (Vlax, Russia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RMB",
-            "locale": "rmn_x_rmb",
-            "vernacular": "ромски (западна България)",
-            "script": "CYRILLIC",
-            "name": "Romany (Western Bulgaria)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RN",
-            "locale": "rng",
-            "vernacular": "Xironga",
-            "script": "ROMAN",
-            "name": "Ronga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RO",
-            "locale": "rtm",
-            "vernacular": "Rotuạm ta",
-            "script": "ROMAN",
-            "name": "Rotuman",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RV",
-            "locale": "rug",
-            "vernacular": "Roviana",
-            "script": "ROMAN",
-            "name": "Roviana",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RKI",
-            "locale": "dru",
-            "vernacular": "Drekay",
-            "script": "ROMAN",
-            "name": "Rukai",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RNY",
-            "locale": "diu",
-            "vernacular": "Rumanyo",
-            "script": "ROMAN",
-            "name": "Rumanyo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RGS",
-            "locale": "drg",
-            "vernacular": "Momogun",
-            "script": "ROMAN",
-            "name": "Rungus",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RR",
-            "locale": "nyn",
-            "vernacular": "Runyankore",
-            "script": "ROMAN",
-            "name": "Runyankore",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "U",
-            "locale": "ru",
-            "vernacular": "русский",
-            "script": "CYRILLIC",
-            "name": "Russian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RSL",
-            "locale": "rsl",
-            "vernacular": "русский жестовый",
-            "script": "CYRILLIC",
-            "name": "Russian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "RSC",
-            "locale": "rue",
-            "vernacular": "Закарпатська русинська",
-            "script": "CYRILLIC",
-            "name": "Rusyn (Carpathian)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RT",
-            "locale": "ttj",
-            "vernacular": "Rutoro",
-            "script": "ROMAN",
-            "name": "Rutoro",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "RWS",
-            "locale": "sgn_rw",
-            "vernacular": "Ururimi rw'amarenga yo mu Rwanda",
-            "script": "ROMAN",
-            "name": "Rwandan Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "RCR",
-            "locale": "rcf",
-            "vernacular": "Kréol Rénioné",
-            "script": "ROMAN",
-            "name": "Réunion Creole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LP",
-            "locale": "se",
-            "vernacular": "sámegiella (davvi)",
-            "script": "ROMAN",
-            "name": "Saami (North)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SDD",
-            "locale": "sck_deva",
-            "vernacular": "सादरी (देवनागरी)",
-            "script": "DEVANAGARI",
-            "name": "Sadri (Devanagari)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LUC",
-            "locale": "acf",
-            "vernacular": "Kwéyòl (Patwa)",
-            "script": "ROMAN",
-            "name": "Saint Lucian Creole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SAL",
-            "locale": "loe",
-            "vernacular": "Saluan",
-            "script": "ROMAN",
-            "name": "Saluan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSS",
-            "locale": "esn",
-            "vernacular": "lengua de señas salvadoreña",
-            "script": "ROMAN",
-            "name": "Salvadoran Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "SBR",
-            "locale": "saq",
-            "vernacular": "Sampur",
-            "script": "ROMAN",
-            "name": "Samburu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LH",
-            "locale": "lsm",
-            "vernacular": "Samia",
-            "script": "ROMAN",
-            "name": "Samia",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SM",
-            "locale": "sm",
-            "vernacular": "Faa-Samoa",
-            "script": "ROMAN",
-            "name": "Samoan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SMS",
-            "locale": "sgn_ws",
-            "vernacular": "Samoan Sign Language",
-            "script": "ROMAN",
-            "name": "Samoan Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "SGA",
-            "locale": "sng",
-            "vernacular": "Kisanga",
-            "script": "ROMAN",
-            "name": "Sanga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SGR",
-            "locale": "sxn",
-            "vernacular": "Sangir",
-            "script": "ROMAN",
-            "name": "Sangir",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SG",
-            "locale": "sg",
-            "vernacular": "Sango",
-            "script": "ROMAN",
-            "name": "Sango",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SHD",
-            "locale": "sat_deva",
-            "vernacular": "Santhali (Devanagari)",
-            "script": "DEVANAGARI",
-            "name": "Santhali (Devanagari)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SHR",
-            "locale": "sat",
-            "vernacular": "Santhali (Roman)",
-            "script": "ROMAN",
-            "name": "Santhali (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SAR",
-            "locale": "mwm",
-            "vernacular": "Sar",
-            "script": "ROMAN",
-            "name": "Sar",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SRM",
-            "locale": "srm",
-            "vernacular": "Saamakatöngö",
-            "script": "ROMAN",
-            "name": "Saramaccan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SRI",
-            "locale": "hns",
-            "vernacular": "Sarnami Hindoestani",
-            "script": "ROMAN",
-            "name": "Sarnami",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SSK",
-            "locale": "sas",
-            "vernacular": "Sasak",
-            "script": "ROMAN",
-            "name": "Sasak",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "STM",
-            "locale": "mav",
-            "vernacular": "Satere Mawe",
-            "script": "ROMAN",
-            "name": "Sateré-Mawé",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "GCS",
-            "locale": "gd",
-            "vernacular": "Gàidhlig",
-            "script": "ROMAN",
-            "name": "Scottish Gaelic",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SDQ",
-            "locale": "trv_x_sdq",
-            "vernacular": "Seediq",
-            "script": "ROMAN",
-            "name": "Seediq",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SHW",
-            "locale": "sfw",
-            "vernacular": "Sehwi",
-            "script": "ROMAN",
-            "name": "Sehwi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SEN",
-            "locale": "seh",
-            "vernacular": "Cisena",
-            "script": "ROMAN",
-            "name": "Sena",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SFC",
-            "locale": "sef",
-            "vernacular": "Senarì",
-            "script": "ROMAN",
-            "name": "Senoufo (Cebaara)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SE",
-            "locale": "nso",
-            "vernacular": "Sepedi",
-            "script": "ROMAN",
-            "name": "Sepedi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SPL",
-            "locale": "nso_x_spl",
-            "vernacular": "Sepulana",
-            "script": "ROMAN",
-            "name": "Sepulana",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SB",
-            "locale": "sr_cyrl",
-            "vernacular": "српски (ћирилица)",
-            "script": "CYRILLIC",
-            "name": "Serbian (Cyrillic)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SBO",
-            "locale": "sr_latn",
-            "vernacular": "srpski (latinica)",
-            "script": "ROMAN",
-            "name": "Serbian (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SBS",
-            "locale": "sgn_rs",
-            "vernacular": "srpski znakovni jezik",
-            "script": "CYRILLIC",
-            "name": "Serbian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "ER",
-            "locale": "srr",
-            "vernacular": "Seereer",
-            "script": "ROMAN",
-            "name": "Serer",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SU",
-            "locale": "st",
-            "vernacular": "Sesotho (Lesotho)",
-            "script": "ROMAN",
-            "name": "Sesotho (Lesotho)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SSA",
-            "locale": "st_za",
-            "vernacular": "Sesotho (South Africa)",
-            "script": "ROMAN",
-            "name": "Sesotho (South Africa)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TN",
-            "locale": "tn",
-            "vernacular": "Setswana",
-            "script": "ROMAN",
-            "name": "Setswana",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SC",
-            "locale": "crs",
-            "vernacular": "Kreol Seselwa",
-            "script": "ROMAN",
-            "name": "Seychelles Creole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SHA",
-            "locale": "shn",
-            "vernacular": "Shan",
-            "script": "MYANMAR",
-            "name": "Shan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HWI",
-            "locale": "cbt",
-            "vernacular": "shawi",
-            "script": "ROMAN",
-            "name": "Shawi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SL",
-            "locale": "shk",
-            "vernacular": "Dhøg Cøllø",
-            "script": "ROMAN",
-            "name": "Shilluk",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SHC",
-            "locale": "shp",
-            "vernacular": "shipibo-conibo",
-            "script": "ROMAN",
-            "name": "Shipibo-Conibo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CA",
-            "locale": "sn",
-            "vernacular": "Shona",
-            "script": "ROMAN",
-            "name": "Shona",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SHU",
-            "locale": "jiv",
-            "vernacular": "shuar",
-            "script": "ROMAN",
-            "name": "Shuar",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SGH",
-            "locale": "sgh",
-            "vernacular": "шуғнонӣ",
-            "script": "CYRILLIC",
-            "name": "Shughni",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "DM",
-            "locale": "sid",
-            "vernacular": "Sidaamu Afoo",
-            "script": "ROMAN",
-            "name": "Sidama",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SSN",
-            "locale": "szl",
-            "vernacular": "jynzyk Ślónska Cieszyńskigo",
-            "script": "ROMAN",
-            "name": "Silesian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SK",
-            "locale": "loz",
-            "vernacular": "Silozi",
-            "script": "ROMAN",
-            "name": "Silozi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NDV",
-            "locale": "sd_deva",
-            "vernacular": "Sindhi (Devanagari)",
-            "script": "DEVANAGARI",
-            "name": "Sindhi (Devanagari)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "NDN",
-            "locale": "snd_x_ndn",
-            "vernacular": "Sindhi (Indonesia)",
-            "script": "ROMAN",
-            "name": "Sindhi (Indonesia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SGL",
-            "locale": "sls",
-            "vernacular": "Singapore Sign Language",
-            "script": "ROMAN",
-            "name": "Singapore Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "SN",
-            "locale": "si",
-            "vernacular": "සිංහල",
-            "script": "SINHALESE",
-            "name": "Sinhala",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "V",
-            "locale": "sk",
-            "vernacular": "slovenčina",
-            "script": "ROMAN",
-            "name": "Slovak",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "VSL",
-            "locale": "svk",
-            "vernacular": "slovenský posunkový jazyk",
-            "script": "ROMAN",
-            "name": "Slovak Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "SV",
-            "locale": "sl",
-            "vernacular": "slovenščina",
-            "script": "ROMAN",
-            "name": "Slovenian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SZJ",
-            "locale": "sgn_si",
-            "vernacular": "slovenski znakovni jezik",
-            "script": "ROMAN",
-            "name": "Slovenian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "SOL",
-            "locale": "sby",
-            "vernacular": "Cisoli",
-            "script": "ROMAN",
-            "name": "Soli",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SP",
-            "locale": "pis",
-            "vernacular": "Solomon Islands Pidgin",
-            "script": "ROMAN",
-            "name": "Solomon Islands Pidgin",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SO",
-            "locale": "so",
-            "vernacular": "Soomaali",
-            "script": "ROMAN",
-            "name": "Somali",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SGO",
-            "locale": "nsx",
-            "vernacular": "Songo",
-            "script": "ROMAN",
-            "name": "Songo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SGM",
-            "locale": "soe",
-            "vernacular": "Losongomino",
-            "script": "ROMAN",
-            "name": "Songomeno",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SNK",
-            "locale": "snk",
-            "vernacular": "Soninke",
-            "script": "ROMAN",
-            "name": "Soninke",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SAS",
-            "locale": "sfs",
-            "vernacular": "South African Sign Language",
-            "script": "ROMAN",
-            "name": "South African Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "SSP",
-            "locale": "es_es",
-            "vernacular": "español (de&nbsp;España)",
-            "script": "ROMAN",
-            "name": "Spanish (Spain)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSE",
-            "locale": "ssp",
-            "vernacular": "lengua de signos española",
-            "script": "ROMAN",
-            "name": "Spanish Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "SR",
-            "locale": "srn",
-            "vernacular": "Sranantongo",
-            "script": "ROMAN",
-            "name": "Sranantongo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SLS",
-            "locale": "sqs",
-            "vernacular": "ශ්‍රී ලංකා සංඥා භාෂාව",
-            "script": "SINHALESE",
-            "name": "Sri Lankan Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "UK",
-            "locale": "suk",
-            "vernacular": "Kisukuma",
-            "script": "ROMAN",
-            "name": "Sukuma",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SD",
-            "locale": "su",
-            "vernacular": "Sunda",
-            "script": "ROMAN",
-            "name": "Sunda",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ODN",
-            "locale": "ory_x_odn",
-            "vernacular": "Sundargadi",
-            "script": "ROMAN",
-            "name": "Sundargadi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SRG",
-            "locale": "sgd",
-            "vernacular": "Surigaonon",
-            "script": "ROMAN",
-            "name": "Surigaonon",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SSU",
-            "locale": "sgn_sr",
-            "vernacular": "Surinaamse Gebarentaal",
-            "script": "ROMAN",
-            "name": "Suriname Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "SUS",
-            "locale": "sus",
-            "vernacular": "Soso xui",
-            "script": "ROMAN",
-            "name": "Susu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SVL",
-            "locale": "sva_x_svl",
-            "vernacular": "ჩუბე ლუშვანუ",
-            "script": "GEORGIAN",
-            "name": "Svan (Lower)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SVN",
-            "locale": "sva_x_svn",
-            "vernacular": "ჟიბე ლუშნუ",
-            "script": "GEORGIAN",
-            "name": "Svan (Upper)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SW",
-            "locale": "sw",
-            "vernacular": "Kiswahili",
-            "script": "ROMAN",
-            "name": "Swahili",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZS",
-            "locale": "swc",
-            "vernacular": "Kiswahili (Congo)",
-            "script": "ROMAN",
-            "name": "Swahili (Congo)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SWK",
-            "locale": "swc_x_swk",
-            "vernacular": "Swahili (Katanga)",
-            "script": "ROMAN",
-            "name": "Swahili (Katanga)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SWI",
-            "locale": "ss",
-            "vernacular": "SiSwati",
-            "script": "ROMAN",
-            "name": "Swati",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SWS",
-            "locale": "sgn_sz",
-            "vernacular": "Swazi Sign Language",
-            "script": "ROMAN",
-            "name": "Swazi Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "Z",
-            "locale": "sv",
-            "vernacular": "Svenska",
-            "script": "ROMAN",
-            "name": "Swedish",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SSL",
-            "locale": "swl",
-            "vernacular": "Svenskt teckenspråk",
-            "script": "ROMAN",
-            "name": "Swedish Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "XSW",
-            "locale": "gsw",
-            "vernacular": "Schweizerdeutsch",
-            "script": "ROMAN",
-            "name": "Swiss German",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SGS",
-            "locale": "sgg",
-            "vernacular": "Deutschschweizer Gebärdensprache",
-            "script": "ROMAN",
-            "name": "Swiss German Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "SYL",
-            "locale": "syl_x_syl",
-            "vernacular": "সেলেটি (বাংলা)",
-            "script": "BENGALI",
-            "name": "Sylheti (Bengali)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "STN",
-            "locale": "cri",
-            "vernacular": "Santome",
-            "script": "ROMAN",
-            "name": "Sãotomense",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TBW",
-            "locale": "tap",
-            "vernacular": "Taabwa",
-            "script": "ROMAN",
-            "name": "Taabwa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TBN",
-            "locale": "tab",
-            "vernacular": "табасаран",
-            "script": "CYRILLIC",
-            "name": "Tabasaran",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TG",
-            "locale": "tl",
-            "vernacular": "Tagalog",
-            "script": "ROMAN",
-            "name": "Tagalog",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TH",
-            "locale": "ty",
-            "vernacular": "Tahiti",
-            "script": "ROMAN",
-            "name": "Tahitian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "KE",
-            "locale": "uar",
-            "vernacular": "Tairuma",
-            "script": "ROMAN",
-            "name": "Tairuma",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AT",
-            "locale": "dav",
-            "vernacular": "Kidawida",
-            "script": "ROMAN",
-            "name": "Taita",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TSL",
-            "locale": "tss",
-            "vernacular": "台灣手語",
-            "script": "CHINESE",
-            "name": "Taiwanese Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "TJ",
-            "locale": "tg",
-            "vernacular": "тоҷикӣ",
-            "script": "CYRILLIC",
-            "name": "Tajiki",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TJU",
-            "locale": "tg_uz",
-            "vernacular": "тоҷикӣ (Самарқанд)",
-            "script": "CYRILLIC",
-            "name": "Tajiki (Samarkand)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TAL",
-            "locale": "vec",
-            "vernacular": "Talian",
-            "script": "ROMAN",
-            "name": "Talian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TLY",
-            "locale": "tly_x_tly",
-            "vernacular": "Toloş",
-            "script": "ROMAN",
-            "name": "Talysh",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TME",
-            "locale": "taj",
-            "vernacular": "Tamang (Eastern)",
-            "script": "ROMAN",
-            "name": "Tamang (Eastern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TMW",
-            "locale": "tdj",
-            "vernacular": "Tamang (Western)",
-            "script": "ROMAN",
-            "name": "Tamang (Western)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TL",
-            "locale": "ta",
-            "vernacular": "தமிழ்",
-            "script": "TAMIL",
-            "name": "Tamil",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TLR",
-            "locale": "ta_x_tlr",
-            "vernacular": "Thamil (Rōman)",
-            "script": "ROMAN",
-            "name": "Tamil (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TND",
-            "locale": "tdx",
-            "vernacular": "Tandroy",
-            "script": "ROMAN",
-            "name": "Tandroy",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TT",
-            "locale": "nmf",
-            "vernacular": "Tangkhul",
-            "script": "ROMAN",
-            "name": "Tangkhul",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TNK",
-            "locale": "xmv",
-            "vernacular": "Tankarana",
-            "script": "ROMAN",
-            "name": "Tankarana",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TZL",
-            "locale": "tza",
-            "vernacular": "Lugha ya Alama ya Tanzania",
-            "script": "ROMAN",
-            "name": "Tanzanian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "TRH",
-            "locale": "tar",
-            "vernacular": "ralámuli",
-            "script": "ROMAN",
-            "name": "Tarahumara (Central)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TRW",
-            "locale": "tac",
-            "vernacular": "tarahumara occidental",
-            "script": "ROMAN",
-            "name": "Tarahumara (Western)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TRS",
-            "locale": "tsz",
-            "vernacular": "Purépecha",
-            "script": "ROMAN",
-            "name": "Tarascan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YG",
-            "locale": "yer",
-            "vernacular": "Tarok",
-            "script": "ROMAN",
-            "name": "Tarok",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TRK",
-            "locale": "trv_x_trk",
-            "vernacular": "Truku",
-            "script": "ROMAN",
-            "name": "Taroko",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TAT",
-            "locale": "tt",
-            "vernacular": "татар",
-            "script": "CYRILLIC",
-            "name": "Tatar",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TA",
-            "locale": "tsg",
-            "vernacular": "Tausug",
-            "script": "ROMAN",
-            "name": "Tausug",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TU",
-            "locale": "te",
-            "vernacular": "తెలుగు",
-            "script": "TELUGU",
-            "name": "Telugu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TEM",
-            "locale": "kdh",
-            "vernacular": "Kotokoli",
-            "script": "ROMAN",
-            "name": "Tem",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CHD",
-            "locale": "nan_x_chd",
-            "vernacular": "潮州",
-            "script": "CHINESE",
-            "name": "Teochew",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TWD",
-            "locale": "nan_x_twd",
-            "vernacular": "Teochew (Indonesia)",
-            "script": "ROMAN",
-            "name": "Teochew (Indonesia)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TER",
-            "locale": "ter",
-            "vernacular": "Terêna",
-            "script": "ROMAN",
-            "name": "Terêna",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TTB",
-            "locale": "tet",
-            "vernacular": "Tetun Belu",
-            "script": "ROMAN",
-            "name": "Tetun Belu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TTP",
-            "locale": "tdt",
-            "vernacular": "Tetun Dili",
-            "script": "ROMAN",
-            "name": "Tetun Dili",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TEW",
-            "locale": "twx",
-            "vernacular": "Ciutee",
-            "script": "ROMAN",
-            "name": "Tewe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SI",
-            "locale": "th",
-            "vernacular": "ไทย",
-            "script": "THAI",
-            "name": "Thai",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SIK",
-            "locale": "th_x_sik",
-            "vernacular": "ไทย (โคราช)",
-            "script": "THAI",
-            "name": "Thai (Korat)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SIE",
-            "locale": "tts",
-            "vernacular": "อีสาน",
-            "script": "THAI",
-            "name": "Thai (Northeastern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SIR",
-            "locale": "nod",
-            "vernacular": "กำเมือง",
-            "script": "THAI",
-            "name": "Thai (Northern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SIS",
-            "locale": "sou",
-            "vernacular": "ไทย (ใต้)",
-            "script": "THAI",
-            "name": "Thai (Southern)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SIL",
-            "locale": "tsq",
-            "vernacular": "ภาษามือไทย",
-            "script": "THAI",
-            "name": "Thai Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "SIG",
-            "locale": "soa",
-            "vernacular": "ไทยซ้ง",
-            "script": "THAI",
-            "name": "Thai Song",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TMN",
-            "locale": "tem",
-            "vernacular": "Themne",
-            "script": "ROMAN",
-            "name": "Themne",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TBT",
-            "locale": "bo",
-            "vernacular": "བོད་སྐད།",
-            "script": "TIBETAN",
-            "name": "Tibetan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TCN",
-            "locale": "tca",
-            "vernacular": "Ticuna",
-            "script": "ROMAN",
-            "name": "Ticuna",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TI",
-            "locale": "ti",
-            "vernacular": "ትግርኛ",
-            "script": "ETHIOPIC",
-            "name": "Tigrinya",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TII",
-            "locale": "txq",
-            "vernacular": "Rote Tii",
-            "script": "ROMAN",
-            "name": "Tii",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TV",
-            "locale": "tiv",
-            "vernacular": "Tiv",
-            "script": "ROMAN",
-            "name": "Tiv",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TLN",
-            "locale": "tcf",
-            "vernacular": "me̱ʼpha̱a̱",
-            "script": "ROMAN",
-            "name": "Tlapanec",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OB",
-            "locale": "mlu",
-            "vernacular": "Toabaita",
-            "script": "ROMAN",
-            "name": "To'abaita",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TR",
-            "locale": "tqo",
-            "vernacular": "Toaripi",
-            "script": "ROMAN",
-            "name": "Toaripi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TOB",
-            "locale": "tob",
-            "vernacular": "toba",
-            "script": "ROMAN",
-            "name": "Toba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TGS",
-            "locale": "sgn_tg",
-            "vernacular": "Togo Sign Language",
-            "script": "ROMAN",
-            "name": "Togo Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "TJO",
-            "locale": "toj",
-            "vernacular": "tojol-abʼal",
-            "script": "ROMAN",
-            "name": "Tojolabal",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "MP",
-            "locale": "tpi",
-            "vernacular": "Tok Pisin",
-            "script": "ROMAN",
-            "name": "Tok Pisin",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "OE",
-            "locale": "tkl",
-            "vernacular": "Faka-Tokelau",
-            "script": "ROMAN",
-            "name": "Tokelauan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TO",
-            "locale": "to",
-            "vernacular": "Faka-Tonga",
-            "script": "ROMAN",
-            "name": "Tongan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TOR",
-            "locale": "sda",
-            "vernacular": "Toraja",
-            "script": "ROMAN",
-            "name": "Toraja",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TSC",
-            "locale": "tcs",
-            "vernacular": "Tores Streit Kriol",
-            "script": "ROMAN",
-            "name": "Torres Strait Creole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TOT",
-            "locale": "top",
-            "vernacular": "totonaco",
-            "script": "ROMAN",
-            "name": "Totonac",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TPR",
-            "locale": "tui",
-            "vernacular": "Toupouri",
-            "script": "ROMAN",
-            "name": "Toupouri",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TTS",
-            "locale": "lst",
-            "vernacular": "Trinidad and Tobago Sign Language",
-            "script": "ROMAN",
-            "name": "Trinidad and Tobago Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "TRC",
-            "locale": "trf",
-            "vernacular": "Trinidadian Creole",
-            "script": "ROMAN",
-            "name": "Trinidadian Creole",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SH",
-            "locale": "lua",
-            "vernacular": "Tshiluba",
-            "script": "ROMAN",
-            "name": "Tshiluba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "AW",
-            "locale": "tsc",
-            "vernacular": "ciTshwa",
-            "script": "ROMAN",
-            "name": "Tshwa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TSM",
-            "locale": "cas",
-            "vernacular": "Tsimané",
-            "script": "ROMAN",
-            "name": "Tsimané",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TMH",
-            "locale": "xmw",
-            "vernacular": "Tsimihety",
-            "script": "ROMAN",
-            "name": "Tsimihety",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TS",
-            "locale": "ts",
-            "vernacular": "Xitsonga",
-            "script": "ROMAN",
-            "name": "Tsonga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TUO",
-            "locale": "tuo",
-            "vernacular": "Dahse ye",
-            "script": "ROMAN",
-            "name": "Tucano",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TLU",
-            "locale": "tcy",
-            "vernacular": "ತುಳು",
-            "script": "KANNADA",
-            "name": "Tulu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TNN",
-            "locale": "tvu",
-            "vernacular": "Banen",
-            "script": "ROMAN",
-            "name": "Tunen",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TRN",
-            "locale": "tuv",
-            "vernacular": "Ng'aturkana",
-            "script": "ROMAN",
-            "name": "Turkana",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TK",
-            "locale": "tr",
-            "vernacular": "Türkçe",
-            "script": "ROMAN",
-            "name": "Turkish",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TKM",
-            "locale": "tur_x_tkm",
-            "vernacular": "ахыска",
-            "script": "ROMAN",
-            "name": "Turkish (Meskhetian)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TKL",
-            "locale": "tsm",
-            "vernacular": "Türk İşaret Dili",
-            "script": "ROMAN",
-            "name": "Turkish Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "TMR",
-            "locale": "tk",
-            "vernacular": "türkmen",
-            "script": "ROMAN",
-            "name": "Turkmen",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TM",
-            "locale": "tk_cyrl",
-            "vernacular": "түркмен (кириллица)",
-            "script": "CYRILLIC",
-            "name": "Turkmen (Cyrillic)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "VL",
-            "locale": "tvl",
-            "vernacular": "Tuvalu",
-            "script": "ROMAN",
-            "name": "Tuvaluan",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "VI",
-            "locale": "tyv",
-            "vernacular": "тыва",
-            "script": "CYRILLIC",
-            "name": "Tuvinian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TW",
-            "locale": "tw",
-            "vernacular": "Twi",
-            "script": "ROMAN",
-            "name": "Twi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TYW",
-            "locale": "car_x_tyw",
-            "vernacular": "Tilewuyu",
-            "script": "ROMAN",
-            "name": "Tyrewuju",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TZE",
-            "locale": "tzh",
-            "vernacular": "tseltal",
-            "script": "ROMAN",
-            "name": "Tzeltal",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TZO",
-            "locale": "tzo",
-            "vernacular": "tsotsil",
-            "script": "ROMAN",
-            "name": "Tzotzil",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "TZU",
-            "locale": "tzj",
-            "vernacular": "tzʼutujil",
-            "script": "ROMAN",
-            "name": "Tzutujil",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "UBM",
-            "locale": "aoz",
-            "vernacular": "Timor Dawan",
-            "script": "ROMAN",
-            "name": "Uab Meto",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "UM",
-            "locale": "udm",
-            "vernacular": "удмурт",
-            "script": "CYRILLIC",
-            "name": "Udmurt",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "USL",
-            "locale": "ugn",
-            "vernacular": "Ugandan Sign Language",
-            "script": "ROMAN",
-            "name": "Ugandan Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "UGA",
-            "locale": "ug_x_uga",
-            "vernacular": "ئۇيغۇر تىلى ‏(‏ئەرەب يېزىقى‏)‏‏‏‏",
-            "script": "ARABIC",
-            "name": "Uighur (Arabic)",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "UG",
-            "locale": "ug_cyrl",
-            "vernacular": "Уйғур (кирилл йезиғи)",
-            "script": "CYRILLIC",
-            "name": "Uighur (Cyrillic)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "K",
-            "locale": "uk",
-            "vernacular": "українська",
-            "script": "CYRILLIC",
-            "name": "Ukrainian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "UB",
-            "locale": "umb",
-            "vernacular": "Umbundu",
-            "script": "ROMAN",
-            "name": "Umbundu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "UD",
-            "locale": "ur",
-            "vernacular": "اُردو",
-            "script": "URDU",
-            "name": "Urdu",
-            "isSignLanguage": false,
-            "isRTL": true
-        },
-        {
-            "code": "UR",
-            "locale": "urh",
-            "vernacular": "Urhobo",
-            "script": "ROMAN",
-            "name": "Urhobo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "URP",
-            "locale": "upv",
-            "vernacular": "Uripiv",
-            "script": "ROMAN",
-            "name": "Uripiv",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSU",
-            "locale": "ugy",
-            "vernacular": "lengua de señas uruguaya",
-            "script": "ROMAN",
-            "name": "Uruguayan Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "DR",
-            "locale": "rnd",
-            "vernacular": "Uruund",
-            "script": "ROMAN",
-            "name": "Uruund",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "UZ",
-            "locale": "uz_cyrl",
-            "vernacular": "ўзбекча",
-            "script": "CYRILLIC",
-            "name": "Uzbek",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "UZH",
-            "locale": "uzn_x_uzh",
-            "vernacular": "ўзбекча (хоразм шеваси)",
-            "script": "CYRILLIC",
-            "name": "Uzbek (Horezm)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "UZR",
-            "locale": "uz_latn",
-            "vernacular": "o‘zbekcha (lotincha)",
-            "script": "ROMAN",
-            "name": "Uzbek (Roman)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "VLC",
-            "locale": "ca_x_vlc",
-            "vernacular": "valencià",
-            "script": "ROMAN",
-            "name": "Valencian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "VE",
-            "locale": "ve",
-            "vernacular": "Luvenda",
-            "script": "ROMAN",
-            "name": "Venda",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LSV",
-            "locale": "vsl",
-            "vernacular": "lengua de señas venezolana",
-            "script": "ROMAN",
-            "name": "Venezuelan Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "VZ",
-            "locale": "skg_x_vz",
-            "vernacular": "Vezo",
-            "script": "ROMAN",
-            "name": "Vezo",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SLV",
-            "locale": "hab",
-            "vernacular": "Việt Nam (Ngôn ngữ ký hiệu)",
-            "script": "ROMAN",
-            "name": "Vietnamese Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "VRU",
-            "locale": "vro",
-            "vernacular": "võro",
-            "script": "ROMAN",
-            "name": "Voru",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WAM",
-            "locale": "prk",
-            "vernacular": "Vax",
-            "script": "ROMAN",
-            "name": "Wa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WMM",
-            "locale": "wwa",
-            "vernacular": "Waama",
-            "script": "ROMAN",
-            "name": "Waama",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WA",
-            "locale": "wls",
-            "vernacular": "Faka'uvea",
-            "script": "ROMAN",
-            "name": "Wallisian",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "LW",
-            "locale": "lwg",
-            "vernacular": "Kiwanga",
-            "script": "ROMAN",
-            "name": "Wanga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WPH",
-            "locale": "wap",
-            "vernacular": "Wapichana",
-            "script": "ROMAN",
-            "name": "Wapishana",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WRO",
-            "locale": "wba",
-            "vernacular": "warao",
-            "script": "ROMAN",
-            "name": "Warao",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "SA",
-            "locale": "war",
-            "vernacular": "Waray-Waray",
-            "script": "ROMAN",
-            "name": "Waray-Waray",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WY",
-            "locale": "guc",
-            "vernacular": "Wayuunaiki",
-            "script": "ROMAN",
-            "name": "Wayuunaiki",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WJW",
-            "locale": "wew",
-            "vernacular": "Wejewa (Sumba Barat)",
-            "script": "ROMAN",
-            "name": "Wejewa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "W",
-            "locale": "cy",
-            "vernacular": "Cymraeg",
-            "script": "ROMAN",
-            "name": "Welsh",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WCH",
-            "locale": "mzh",
-            "vernacular": "wichí",
-            "script": "ROMAN",
-            "name": "Wichi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WCB",
-            "locale": "wlv",
-            "vernacular": "Wichi (Bermejo)",
-            "script": "ROMAN",
-            "name": "Wichi (Bermejo)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "HCH",
-            "locale": "hch",
-            "vernacular": "wixárika",
-            "script": "ROMAN",
-            "name": "Wixárika",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WL",
-            "locale": "wal",
-            "vernacular": "Wolayttattuwa",
-            "script": "ROMAN",
-            "name": "Wolaita",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "WO",
-            "locale": "wo",
-            "vernacular": "wolof",
-            "script": "ROMAN",
-            "name": "Wolof",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "XV",
-            "locale": "xav",
-            "vernacular": "A'uwẽ mreme",
-            "script": "ROMAN",
-            "name": "Xavante",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "XO",
-            "locale": "xh",
-            "vernacular": "IsiXhosa",
-            "script": "ROMAN",
-            "name": "Xhosa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "XRC",
-            "locale": "ane",
-            "vernacular": "Xârâcùù",
-            "script": "ROMAN",
-            "name": "Xârâcùù",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YCB",
-            "locale": "daf",
-            "vernacular": "Yaoba",
-            "script": "ROMAN",
-            "name": "Yacouba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YAK",
-            "locale": "yaf",
-            "vernacular": "Iyaka",
-            "script": "ROMAN",
-            "name": "Yaka",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YKM",
-            "locale": "yky",
-            "vernacular": "Yakoma",
-            "script": "ROMAN",
-            "name": "Yakoma",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YK",
-            "locale": "sah",
-            "vernacular": "сахалыы",
-            "script": "CYRILLIC",
-            "name": "Yakutsk",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YBS",
-            "locale": "yas",
-            "vernacular": "Yambassa",
-            "script": "ROMAN",
-            "name": "Yambassa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YMI",
-            "locale": "tao",
-            "vernacular": "Yami",
-            "script": "ROMAN",
-            "name": "Yami",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YNS",
-            "locale": "yns",
-            "vernacular": "Iyanzi",
-            "script": "ROMAN",
-            "name": "Yansi",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YP",
-            "locale": "yap",
-            "vernacular": "Waab",
-            "script": "ROMAN",
-            "name": "Yapese",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YQ",
-            "locale": "yaq",
-            "vernacular": "jiiak noki",
-            "script": "ROMAN",
-            "name": "Yaqui",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "BM",
-            "locale": "ybb",
-            "vernacular": "Dschang",
-            "script": "ROMAN",
-            "name": "Yemba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YMB",
-            "locale": "yom_x_ymb",
-            "vernacular": "Yombe",
-            "script": "ROMAN",
-            "name": "Yombe",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YN",
-            "locale": "yno",
-            "vernacular": "Yong",
-            "script": "THAI",
-            "name": "Yong",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YR",
-            "locale": "yo",
-            "vernacular": "Yorùbá",
-            "script": "ROMAN",
-            "name": "Yoruba",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YNG",
-            "locale": "nua",
-            "vernacular": "Yuanga",
-            "script": "ROMAN",
-            "name": "Yuanga",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "YKP",
-            "locale": "yup",
-            "vernacular": "yukpa",
-            "script": "ROMAN",
-            "name": "Yukpa",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZAS",
-            "locale": "zsl",
-            "vernacular": "Zambian Sign Language",
-            "script": "ROMAN",
-            "name": "Zambian Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "ZN",
-            "locale": "zne",
-            "vernacular": "Zande",
-            "script": "ROMAN",
-            "name": "Zande",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZPG",
-            "locale": "zpg",
-            "vernacular": "dîdzrie’",
-            "script": "ROMAN",
-            "name": "Zapotec (Guevea)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZPI",
-            "locale": "zai",
-            "vernacular": "diidxazá",
-            "script": "ROMAN",
-            "name": "Zapotec (Isthmus)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZPX",
-            "locale": "zpd",
-            "vernacular": "Dillexhon",
-            "script": "ROMAN",
-            "name": "Zapotec (Ixtlán)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZPL",
-            "locale": "zpa",
-            "vernacular": "diitza",
-            "script": "ROMAN",
-            "name": "Zapotec (Lachiguiri)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZPM",
-            "locale": "ztp",
-            "vernacular": "diʼste Loxich",
-            "script": "ROMAN",
-            "name": "Zapotec (Loxicha)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZPT",
-            "locale": "zpf",
-            "vernacular": "zapoteco de Quiatoni",
-            "script": "ROMAN",
-            "name": "Zapotec (Quiatoni)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZPC",
-            "locale": "zpj",
-            "vernacular": "ditz zea",
-            "script": "ROMAN",
-            "name": "Zapotec (Quiavicuzas)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZPS",
-            "locale": "zpr",
-            "vernacular": "Zapotec (Santiago Xanica)",
-            "script": "ROMAN",
-            "name": "Zapotec (Santiago Xanica)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZPV",
-            "locale": "zav",
-            "vernacular": "didza xhidza",
-            "script": "ROMAN",
-            "name": "Zapotec (Villa Alta)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZPD",
-            "locale": "zab",
-            "vernacular": "ditsa",
-            "script": "ROMAN",
-            "name": "Zapotec (del Valle)",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZR",
-            "locale": "dje",
-            "vernacular": "Zarma",
-            "script": "ROMAN",
-            "name": "Zarma",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "ZSL",
-            "locale": "zib",
-            "vernacular": "Zimbabwe Sign Language",
-            "script": "ROMAN",
-            "name": "Zimbabwe Sign Language",
-            "isSignLanguage": true,
-            "isRTL": false
-        },
-        {
-            "code": "ZU",
-            "locale": "zu",
-            "vernacular": "IsiZulu",
-            "script": "ROMAN",
-            "name": "Zulu",
-            "isSignLanguage": false,
-            "isRTL": false
-        },
-        {
-            "code": "CHX",
-            "locale": "nan_x_chx",
-            "vernacular": "中文（海南话）",
-            "script": "ROMAN",
-            "name": "中文（海南话）",
-            "isSignLanguage": false,
-            "isRTL": false
-        }
-    ]
-}
+[
+  {
+    "code": "ABN",
+    "locale": "abx",
+    "vernacular": "Abaknon",
+    "script": "ROMAN",
+    "name": "Abaknon",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ABB",
+    "locale": "aba",
+    "vernacular": "Abɛ",
+    "script": "ROMAN",
+    "name": "Abbey",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ABK",
+    "locale": "ab",
+    "vernacular": "аԥсуа",
+    "script": "CYRILLIC",
+    "name": "Abkhaz",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AU",
+    "locale": "abn",
+    "vernacular": "Abua",
+    "script": "ROMAN",
+    "name": "Abua",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ABU",
+    "locale": "abz",
+    "vernacular": "Alor Abui",
+    "script": "ROMAN",
+    "name": "Abui",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ACD",
+    "locale": "fr_x_acd",
+    "vernacular": "Acadien",
+    "script": "ROMAN",
+    "name": "Acadian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ACH",
+    "locale": "acr",
+    "vernacular": "achi",
+    "script": "ROMAN",
+    "name": "Achi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ACC",
+    "locale": "acr_x_acc",
+    "vernacular": "achí de cubulco",
+    "script": "ROMAN",
+    "name": "Achi (Cubulco)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ACR",
+    "locale": "acr_x_acr",
+    "vernacular": "achí de rabinal",
+    "script": "ROMAN",
+    "name": "Achi (Rabinal)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AC",
+    "locale": "ach",
+    "vernacular": "Acholi",
+    "script": "ROMAN",
+    "name": "Acholi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AHW",
+    "locale": "acu",
+    "vernacular": "achuar-shiwiar",
+    "script": "ROMAN",
+    "name": "Achuar-Shiwiar",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ADH",
+    "locale": "adh",
+    "vernacular": "Dhopadhola",
+    "script": "ROMAN",
+    "name": "Adhola",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AD",
+    "locale": "ady",
+    "vernacular": "адыгабзэ",
+    "script": "CYRILLIC",
+    "name": "Adyghe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AF",
+    "locale": "af",
+    "vernacular": "Afrikaans",
+    "script": "ROMAN",
+    "name": "Afrikaans",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AHN",
+    "locale": "aha",
+    "vernacular": "Aɣɩnda",
+    "script": "ROMAN",
+    "name": "Ahanta",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AJG",
+    "locale": "ajg",
+    "vernacular": "Aja",
+    "script": "ROMAN",
+    "name": "Aja",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HO",
+    "locale": "aji",
+    "vernacular": "A'jië",
+    "script": "ROMAN",
+    "name": "Ajië",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KAN",
+    "locale": "knj",
+    "vernacular": "akateko",
+    "script": "ROMAN",
+    "name": "Akateko",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AKA",
+    "locale": "ahk",
+    "vernacular": "Akha",
+    "script": "ROMAN",
+    "name": "Akha",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AL",
+    "locale": "sq",
+    "vernacular": "shqip",
+    "script": "ROMAN",
+    "name": "Albanian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ALG",
+    "locale": "aln",
+    "vernacular": "Albanian (Gheg)",
+    "script": "ROMAN",
+    "name": "Albanian (Gheg)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ALS",
+    "locale": "sqk",
+    "vernacular": "shqipe e shenjave",
+    "script": "ROMAN",
+    "name": "Albanian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "ALQ",
+    "locale": "alq",
+    "vernacular": "Anishinàbemowin",
+    "script": "ROMAN",
+    "name": "Algonquin",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LTN",
+    "locale": "gsw_x_ltn",
+    "vernacular": "Elsässisch",
+    "script": "ROMAN",
+    "name": "Alsatian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ALT",
+    "locale": "alt",
+    "vernacular": "алтай",
+    "script": "CYRILLIC",
+    "name": "Altai",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ALU",
+    "locale": "alz",
+    "vernacular": "Alur",
+    "script": "ROMAN",
+    "name": "Alur",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ABE",
+    "locale": "omb",
+    "vernacular": "Ambae (East)",
+    "script": "ROMAN",
+    "name": "Ambae (East)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AM",
+    "locale": "am",
+    "vernacular": "አማርኛ",
+    "script": "ETHIOPIC",
+    "name": "Amharic",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AI",
+    "locale": "ami",
+    "vernacular": "阿美語",
+    "script": "ROMAN",
+    "name": "Amis",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AMG",
+    "locale": "amu",
+    "vernacular": "ñoomndaa",
+    "script": "ROMAN",
+    "name": "Amuzgo (Guerrero)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ANM",
+    "locale": "anm",
+    "vernacular": "Anal",
+    "script": "ROMAN",
+    "name": "Anal",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LAS",
+    "locale": "sgn_ao",
+    "vernacular": "Língua angolana de sinais",
+    "script": "ROMAN",
+    "name": "Angolan Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "AYI",
+    "locale": "any_ci",
+    "vernacular": "anyin (indenie)",
+    "script": "ROMAN",
+    "name": "Anyin (Indenie)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "APM",
+    "locale": "app",
+    "vernacular": "Apma",
+    "script": "ROMAN",
+    "name": "Apma",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "A",
+    "locale": "ar",
+    "vernacular": "العربية",
+    "script": "ARABIC",
+    "name": "Arabic",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "ADZ",
+    "locale": "arq",
+    "vernacular": "العربيّة (الدّارجة الجزائريّة)",
+    "script": "ARABIC",
+    "name": "Arabic (Algeria)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "AEY",
+    "locale": "arz",
+    "vernacular": "العربية (اللهجة المصرية)",
+    "script": "ARABIC",
+    "name": "Arabic (Egypt)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "ARQ",
+    "locale": "acm",
+    "vernacular": "العربية (اللهجة‏ ‏العراقية)‏",
+    "script": "ARABIC",
+    "name": "Arabic (Iraq)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "AJD",
+    "locale": "ajp",
+    "vernacular": "العربية (اللهجة‏ ‏الأردنية)‏",
+    "script": "ARABIC",
+    "name": "Arabic (Jordan)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "ALN",
+    "locale": "apc",
+    "vernacular": "العربية (اللهجة اللبنانية)",
+    "script": "ARABIC",
+    "name": "Arabic (Lebanon)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "AMO",
+    "locale": "ary",
+    "vernacular": "العربية (الدارجة المغربية)",
+    "script": "ARABIC",
+    "name": "Arabic (Morocco)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "JU",
+    "locale": "pga",
+    "vernacular": "Arabi Juba",
+    "script": "ROMAN",
+    "name": "Arabic (Sudanese Creole)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ASN",
+    "locale": "apd",
+    "vernacular": "العربية (اللهجة السودانية)",
+    "script": "ARABIC",
+    "name": "Arabic (Sudanese)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "ASR",
+    "locale": "apc_sy",
+    "vernacular": "العربية (اللهجة‏ السورية)‏",
+    "script": "ARABIC",
+    "name": "Arabic (Syria)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "ATN",
+    "locale": "aeb",
+    "vernacular": "العربية (الدّارجة‏ ‏التّونسيّة)",
+    "script": "ARABIC",
+    "name": "Arabic (Tunisia)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "ARH",
+    "locale": "arh",
+    "vernacular": "Arhuaco",
+    "script": "ROMAN",
+    "name": "Arhuaco",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "REA",
+    "locale": "hy",
+    "vernacular": "Հայերեն",
+    "script": "ARMENIAN",
+    "name": "Armenian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KRB",
+    "locale": "hy_x_krb",
+    "vernacular": "Հայերեն (արևելյան բարբառ)",
+    "script": "ARMENIAN",
+    "name": "Armenian (Eastern dialect)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "R",
+    "locale": "hyw",
+    "vernacular": "Արեւմտահայերէն",
+    "script": "ARMENIAN",
+    "name": "Armenian (West)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ARS",
+    "locale": "aen",
+    "vernacular": "Հայերեն ժեստերի լեզու",
+    "script": "ARMENIAN",
+    "name": "Armenian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "AHK",
+    "locale": "cni",
+    "vernacular": "ashaninka",
+    "script": "ROMAN",
+    "name": "Ashaninka",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AE",
+    "locale": "as",
+    "vernacular": "অসমীয়া",
+    "script": "BENGALI",
+    "name": "Assamese",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AS",
+    "locale": "aii",
+    "vernacular": "ܐܵܬܘܿܪܵܝܵܐ",
+    "script": "ASSYRIAN",
+    "name": "Assyrian",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "ACS",
+    "locale": "cld",
+    "vernacular": "Assyro-Chaldean (Silopi)",
+    "script": "ASSYRIAN",
+    "name": "Assyro-Chaldean (Silopi)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ATY",
+    "locale": "tay",
+    "vernacular": "Tayal",
+    "script": "ROMAN",
+    "name": "Atayal",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IE",
+    "locale": "teo",
+    "vernacular": "Ateso",
+    "script": "ROMAN",
+    "name": "Ateso",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ATI",
+    "locale": "ati",
+    "vernacular": "Akie",
+    "script": "ROMAN",
+    "name": "Attié",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AKN",
+    "locale": "djk",
+    "vernacular": "Okanisitongo",
+    "script": "ROMAN",
+    "name": "Aukan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AV",
+    "locale": "av",
+    "vernacular": "магӀарул",
+    "script": "CYRILLIC",
+    "name": "Avar",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AWA",
+    "locale": "kwi",
+    "vernacular": "awapit",
+    "script": "ROMAN",
+    "name": "Awa (Cuaiquer)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AWD",
+    "locale": "awa",
+    "vernacular": "Awadhi",
+    "script": "DEVANAGARI",
+    "name": "Awadhi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AGR",
+    "locale": "agr",
+    "vernacular": "awajun",
+    "script": "ROMAN",
+    "name": "Awajun",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AWN",
+    "locale": "azo",
+    "vernacular": "Awing",
+    "script": "ROMAN",
+    "name": "Awing",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AP",
+    "locale": "ay",
+    "vernacular": "Aymara",
+    "script": "ROMAN",
+    "name": "Aymara",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AJR",
+    "locale": "az",
+    "vernacular": "Azərbaycan",
+    "script": "ROMAN",
+    "name": "Azerbaijani",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AJA",
+    "locale": "azb",
+    "vernacular": "آذربايجانى (عربى)",
+    "script": "ARABIC",
+    "name": "Azerbaijani (Arabic)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "AJ",
+    "locale": "az_cyrl",
+    "vernacular": "Aзәрбајҹан (кирил әлифбасы)",
+    "script": "CYRILLIC",
+    "name": "Azerbaijani (Cyrillic)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FNB",
+    "locale": "wyy_x_fnb",
+    "vernacular": "Ba",
+    "script": "ROMAN",
+    "name": "Ba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BCM",
+    "locale": "bcy",
+    "vernacular": "Bacama",
+    "script": "ROMAN",
+    "name": "Bacama",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BDG",
+    "locale": "bfq",
+    "vernacular": "படகா",
+    "script": "TAMIL",
+    "name": "Badaga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BFI",
+    "locale": "ksf",
+    "vernacular": "bafia (rikpag)",
+    "script": "ROMAN",
+    "name": "Bafia",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BNR",
+    "locale": "bdq",
+    "vernacular": "Bahnar",
+    "script": "ROMAN",
+    "name": "Bahnar",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BKK",
+    "locale": "bkh",
+    "vernacular": "Bakoko",
+    "script": "ROMAN",
+    "name": "Bakoko",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BLN",
+    "locale": "ban",
+    "vernacular": "Bali",
+    "script": "ROMAN",
+    "name": "Balinese",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AR",
+    "locale": "bm",
+    "vernacular": "Bamanankan",
+    "script": "ROMAN",
+    "name": "Bambara",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BMN",
+    "locale": "bax",
+    "vernacular": "Shü Pamom",
+    "script": "ROMAN",
+    "name": "Bamun",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BNM",
+    "locale": "bjo",
+    "vernacular": "Banda (Mid-Southern)",
+    "script": "ROMAN",
+    "name": "Banda (Mid-Southern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BNW",
+    "locale": "bwi",
+    "vernacular": "Baniua",
+    "script": "ROMAN",
+    "name": "Baniwa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BNJ",
+    "locale": "bjn",
+    "vernacular": "Banjar",
+    "script": "ROMAN",
+    "name": "Banjar",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AO",
+    "locale": "bci",
+    "vernacular": "Wawle",
+    "script": "ROMAN",
+    "name": "Baoule",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BH",
+    "locale": "bfa",
+    "vernacular": "Bari",
+    "script": "ROMAN",
+    "name": "Bari",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BB",
+    "locale": "bba",
+    "vernacular": "Baatɔnum",
+    "script": "ROMAN",
+    "name": "Bariba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BRW",
+    "locale": "bwg",
+    "vernacular": "Barwe",
+    "script": "ROMAN",
+    "name": "Barwe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BSA",
+    "locale": "mot",
+    "vernacular": "Barí (South America)",
+    "script": "ROMAN",
+    "name": "Barí (South America)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BAK",
+    "locale": "ba",
+    "vernacular": "башҡорт",
+    "script": "CYRILLIC",
+    "name": "Bashkir",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BQ",
+    "locale": "eu",
+    "vernacular": "Euskara",
+    "script": "ROMAN",
+    "name": "Basque",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BS",
+    "locale": "bas",
+    "vernacular": "Basaa (Kamerun)",
+    "script": "ROMAN",
+    "name": "Bassa (Cameroon)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BA",
+    "locale": "bsq",
+    "vernacular": "Ɓǎsɔ́ɔ̀ (Ɖàbíɖà)",
+    "script": "ROMAN",
+    "name": "Bassa (Liberia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BTD",
+    "locale": "btd",
+    "vernacular": "Pakpak",
+    "script": "ROMAN",
+    "name": "Batak (Dairi)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AK",
+    "locale": "btx",
+    "vernacular": "Batak (Karo)",
+    "script": "ROMAN",
+    "name": "Batak (Karo)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BTK",
+    "locale": "bts",
+    "vernacular": "Batak (Simalungun)",
+    "script": "ROMAN",
+    "name": "Batak (Simalungun)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BT",
+    "locale": "bbc",
+    "vernacular": "Batak (Toba)",
+    "script": "ROMAN",
+    "name": "Batak (Toba)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BEA",
+    "locale": "ron_x_bea",
+    "vernacular": "Beas",
+    "script": "ROMAN",
+    "name": "Beas",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BZK",
+    "locale": "bzj",
+    "vernacular": "Bileez Kriol",
+    "script": "ROMAN",
+    "name": "Belize Kriol",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BEL",
+    "locale": "be",
+    "vernacular": "беларуская",
+    "script": "CYRILLIC",
+    "name": "Belorussian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BMB",
+    "locale": "bmb",
+    "vernacular": "Kibembe",
+    "script": "ROMAN",
+    "name": "Bembe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "EN",
+    "locale": "bez",
+    "vernacular": "Bena",
+    "script": "ROMAN",
+    "name": "Bena",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BE",
+    "locale": "bn",
+    "vernacular": "বাংলা",
+    "script": "BENGALI",
+    "name": "Bengali",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BNL",
+    "locale": "sgn_bj",
+    "vernacular": "Benin Sign Language",
+    "script": "ROMAN",
+    "name": "Benin Sign Language",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BRM",
+    "locale": "bom",
+    "vernacular": "Berom",
+    "script": "ROMAN",
+    "name": "Berom",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BTO",
+    "locale": "plt_x_bto",
+    "vernacular": "Betsileo",
+    "script": "ROMAN",
+    "name": "Betsileo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BTS",
+    "locale": "bmm",
+    "vernacular": "Betsimisaraka Avaratra",
+    "script": "ROMAN",
+    "name": "Betsimisaraka (Northern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BTA",
+    "locale": "bzc",
+    "vernacular": "Betsimisaraka Atsimo",
+    "script": "ROMAN",
+    "name": "Betsimisaraka (Southern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BHJ",
+    "locale": "bho",
+    "vernacular": "भोजपुरी",
+    "script": "DEVANAGARI",
+    "name": "Bhojpuri",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BHM",
+    "locale": "bho_mu",
+    "vernacular": "Bhojpuri (Mauritius)",
+    "script": "ROMAN",
+    "name": "Bhojpuri (Mauritius)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IK",
+    "locale": "bhw",
+    "vernacular": "Biak",
+    "script": "ROMAN",
+    "name": "Biak",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BI",
+    "locale": "bcl",
+    "vernacular": "Bicol",
+    "script": "ROMAN",
+    "name": "Bicol",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BDY",
+    "locale": "sdo",
+    "vernacular": "Bidayuh (Bukar)",
+    "script": "ROMAN",
+    "name": "Bidayuh (Bukar)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BLB",
+    "locale": "bib",
+    "vernacular": "Bɩsa",
+    "script": "ROMAN",
+    "name": "Bisa (Lebir)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LM",
+    "locale": "bi",
+    "vernacular": "Bislama",
+    "script": "ROMAN",
+    "name": "Bislama",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TCR",
+    "locale": "pov",
+    "vernacular": "Kriol di Gine-Bisau",
+    "script": "ROMAN",
+    "name": "Bissau Guinean Creole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BNS",
+    "locale": "bps",
+    "vernacular": "Blaan (Sarangani)",
+    "script": "ROMAN",
+    "name": "Blaan (Sarangani)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BLF",
+    "locale": "bla",
+    "vernacular": "Siksikáíitsi'powahsini",
+    "script": "ROMAN",
+    "name": "Blackfoot",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BMU",
+    "locale": "bmq",
+    "vernacular": "Boomu",
+    "script": "ROMAN",
+    "name": "Bomu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BSN",
+    "locale": "bs",
+    "vernacular": "bosanski",
+    "script": "ROMAN",
+    "name": "Bosnian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WSL",
+    "locale": "sgn_bw",
+    "vernacular": "Botswana Sign Language",
+    "script": "ROMAN",
+    "name": "Botswana Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "BO",
+    "locale": "bum",
+    "vernacular": "Bulu",
+    "script": "ROMAN",
+    "name": "Boulou",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BRI",
+    "locale": "bzd",
+    "vernacular": "bribri",
+    "script": "ROMAN",
+    "name": "Bribri",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BDZ",
+    "locale": "bja",
+    "vernacular": "Ebudza",
+    "script": "ROMAN",
+    "name": "Budza",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LK",
+    "locale": "bxk",
+    "vernacular": "Bukusu",
+    "script": "ROMAN",
+    "name": "Bukusu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BL",
+    "locale": "bg",
+    "vernacular": "български",
+    "script": "CYRILLIC",
+    "name": "Bulgarian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BLS",
+    "locale": "bqn",
+    "vernacular": "български жестов език",
+    "script": "CYRILLIC",
+    "name": "Bulgarian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "BNN",
+    "locale": "bnn",
+    "vernacular": "布農語（南部）",
+    "script": "ROMAN",
+    "name": "Bunun (South)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BUR",
+    "locale": "bwr",
+    "vernacular": "Bura",
+    "script": "ROMAN",
+    "name": "Bura",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BY",
+    "locale": "bxr",
+    "vernacular": "буряад",
+    "script": "CYRILLIC",
+    "name": "Buryat",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BSH",
+    "locale": "buc",
+    "vernacular": "Kibushi",
+    "script": "ROMAN",
+    "name": "Bushi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BHL",
+    "locale": "lel",
+    "vernacular": "Bushilele",
+    "script": "ROMAN",
+    "name": "Bushilele",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BSG",
+    "locale": "buf",
+    "vernacular": "Bushoong",
+    "script": "ROMAN",
+    "name": "Bushoong",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ET",
+    "locale": "btg",
+    "vernacular": "ˈBhɛtɩgbʋʋ",
+    "script": "ROMAN",
+    "name": "Bété",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CAB",
+    "locale": "cjp",
+    "vernacular": "cabécar",
+    "script": "ROMAN",
+    "name": "Cabécar (Tayní)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CQC",
+    "locale": "cak_x_cqc",
+    "vernacular": "Kaqchikel central",
+    "script": "ROMAN",
+    "name": "Cakchiquel (Central)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CQE",
+    "locale": "cak_x_cqe",
+    "vernacular": "Kaqchikel oriental",
+    "script": "ROMAN",
+    "name": "Cakchiquel (Eastern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CQ",
+    "locale": "cak",
+    "vernacular": "Kaqchikel occidental",
+    "script": "ROMAN",
+    "name": "Cakchiquel (Western)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CB",
+    "locale": "km",
+    "vernacular": "ខ្មែរ",
+    "script": "CAMBODIAN",
+    "name": "Cambodian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CBL",
+    "locale": "sgn_kh",
+    "vernacular": "ភាសាសញ្ញាខ្មែរ",
+    "script": "CAMBODIAN",
+    "name": "Cambodian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "CRB",
+    "locale": "car_x_crb",
+    "vernacular": "Kariʼnia",
+    "script": "ROMAN",
+    "name": "Carib",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AN",
+    "locale": "cat",
+    "vernacular": "català",
+    "script": "ROMAN",
+    "name": "Catalan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CV",
+    "locale": "ceb",
+    "vernacular": "Cebuano",
+    "script": "ROMAN",
+    "name": "Cebuano",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YU",
+    "locale": "esu",
+    "vernacular": "Central Alaskan Yupik",
+    "script": "ROMAN",
+    "name": "Central Alaskan Yupik",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CM",
+    "locale": "ch",
+    "vernacular": "Chamorro",
+    "script": "ROMAN",
+    "name": "Chamorro",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CGM",
+    "locale": "tso_mz",
+    "vernacular": "xiChangana (Moçambique)",
+    "script": "ROMAN",
+    "name": "Changana (Mozambique)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CGA",
+    "locale": "tso_zw",
+    "vernacular": "Xichangana (Zimbabwe)",
+    "script": "ROMAN",
+    "name": "Changana (Zimbabwe)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CC",
+    "locale": "cbk",
+    "vernacular": "Chavacano",
+    "script": "ROMAN",
+    "name": "Chavacano",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CPL",
+    "locale": "cbi",
+    "vernacular": "cha'palaa",
+    "script": "ROMAN",
+    "name": "Cha’palaa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HE",
+    "locale": "ce",
+    "vernacular": "нохчийн",
+    "script": "CYRILLIC",
+    "name": "Chechen",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CDG",
+    "locale": "arn_x_cdg",
+    "vernacular": "Chedungun labquenche",
+    "script": "ROMAN",
+    "name": "Chedungun (Coast)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CKE",
+    "locale": "chr",
+    "vernacular": "ᏣᎳᎩ ᎦᏬᏂᎯᏍᏗ",
+    "script": "CHEROKEE",
+    "name": "Cherokee",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CGD",
+    "locale": "hne_deva",
+    "vernacular": "छत्तीसगढ़ी (देवनागरी)",
+    "script": "DEVANAGARI",
+    "name": "Chhattisgarhi (Devanagari)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CN",
+    "locale": "ny",
+    "vernacular": "Chichewa",
+    "script": "ROMAN",
+    "name": "Chichewa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CGG",
+    "locale": "cgg",
+    "vernacular": "Orukiga",
+    "script": "ROMAN",
+    "name": "Chiga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FLM",
+    "locale": "cfm",
+    "vernacular": "Chin (Falam)",
+    "script": "ROMAN",
+    "name": "Chin (Falam)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HK",
+    "locale": "cnh",
+    "vernacular": "Chin (Hakha)",
+    "script": "ROMAN",
+    "name": "Chin (Hakha)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KUK",
+    "locale": "tcz",
+    "vernacular": "Chin (Kuki)",
+    "script": "ROMAN",
+    "name": "Chin (Kuki)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MAA",
+    "locale": "mrh",
+    "vernacular": "Chin (Mara)",
+    "script": "ROMAN",
+    "name": "Chin (Mara)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CI",
+    "locale": "ctd",
+    "vernacular": "Chin (Tedim)",
+    "script": "ROMAN",
+    "name": "Chin (Tiddim)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZO",
+    "locale": "czt",
+    "vernacular": "Chin (Zotung)",
+    "script": "ROMAN",
+    "name": "Chin (Zotung)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CNO",
+    "locale": "chj",
+    "vernacular": "jújmi kiʼtsa köwɨ̱",
+    "script": "ROMAN",
+    "name": "Chinantec (Ojitlan)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CHF",
+    "locale": "cdo",
+    "vernacular": "中文（福州话）",
+    "script": "CHINESE",
+    "name": "Chinese (Fuzhounese)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CHG",
+    "locale": "wuu_x_chg",
+    "vernacular": "中文（上海话）",
+    "script": "CHINESE",
+    "name": "Chinese (Shanghainese)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CSN",
+    "locale": "cmn_x_csn",
+    "vernacular": "中文（四川话）",
+    "script": "CHINESE",
+    "name": "Chinese (Sichuanese)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WNZ",
+    "locale": "wuu_x_wnz",
+    "vernacular": "中文（温州话）",
+    "script": "CHINESE",
+    "name": "Chinese (Wenzhounese)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CHK",
+    "locale": "cmn_x_chk",
+    "vernacular": "中文（云南话）",
+    "script": "CHINESE",
+    "name": "Chinese (Yunnanese)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CNS",
+    "locale": "yue_hans",
+    "vernacular": "中文简体（广东话）",
+    "script": "CHINESE",
+    "name": "Chinese Cantonese (Simplified)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CHC",
+    "locale": "yue_hant",
+    "vernacular": "中文繁體（廣東話）",
+    "script": "CHINESE",
+    "name": "Chinese Cantonese (Traditional)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CHS",
+    "locale": "cmn_hans",
+    "vernacular": "中文简体（普通话）",
+    "script": "CHINESE",
+    "name": "Chinese Mandarin (Simplified)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CH",
+    "locale": "cmn_hant",
+    "vernacular": "中文繁體（國語）",
+    "script": "CHINESE",
+    "name": "Chinese Mandarin (Traditional)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CSL",
+    "locale": "csl",
+    "vernacular": "中国手语",
+    "script": "CHINESE",
+    "name": "Chinese Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "CHQ",
+    "locale": "cax",
+    "vernacular": "Chiquitano",
+    "script": "ROMAN",
+    "name": "Chiquitano",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CG",
+    "locale": "toi",
+    "vernacular": "Chitonga",
+    "script": "ROMAN",
+    "name": "Chitonga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CT",
+    "locale": "tog",
+    "vernacular": "Chitonga (Malawi)",
+    "script": "ROMAN",
+    "name": "Chitonga (Malawi)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CGW",
+    "locale": "toi_zw",
+    "vernacular": "Chitonga (Zimbabwe)",
+    "script": "ROMAN",
+    "name": "Chitonga (Zimbabwe)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TB",
+    "locale": "tum",
+    "vernacular": "Chitumbuka",
+    "script": "ROMAN",
+    "name": "Chitumbuka",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YA",
+    "locale": "yao",
+    "vernacular": "Chiyao",
+    "script": "ROMAN",
+    "name": "Chiyao",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CTW",
+    "locale": "cho",
+    "vernacular": "Choctaw",
+    "script": "ROMAN",
+    "name": "Choctaw",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CK",
+    "locale": "cjk",
+    "vernacular": "Chokwe",
+    "script": "ROMAN",
+    "name": "Chokwe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CHL",
+    "locale": "ctu",
+    "vernacular": "ch'ol",
+    "script": "ROMAN",
+    "name": "Chol",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CLX",
+    "locale": "chd",
+    "vernacular": "lataiki",
+    "script": "ROMAN",
+    "name": "Chontal (Oaxaca)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CLT",
+    "locale": "chf",
+    "vernacular": "yokotʼan",
+    "script": "ROMAN",
+    "name": "Chontal (Tabasco)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CPI",
+    "locale": "cce",
+    "vernacular": "Txitxopi",
+    "script": "ROMAN",
+    "name": "Chopi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CTI",
+    "locale": "crt",
+    "vernacular": "chorote (iyojwa'ja)",
+    "script": "ROMAN",
+    "name": "Chorote (Iyojwa'ja)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CO",
+    "locale": "chw",
+    "vernacular": "Etxuwabo",
+    "script": "ROMAN",
+    "name": "Chuabo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CHJ",
+    "locale": "cac",
+    "vernacular": "chuj",
+    "script": "ROMAN",
+    "name": "Chuj",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TE",
+    "locale": "chk",
+    "vernacular": "Chuuk",
+    "script": "ROMAN",
+    "name": "Chuukese",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CU",
+    "locale": "cv",
+    "vernacular": "чӑвашла",
+    "script": "CYRILLIC",
+    "name": "Chuvash",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CW",
+    "locale": "bem",
+    "vernacular": "Cibemba",
+    "script": "ROMAN",
+    "name": "Cibemba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NM",
+    "locale": "mwn",
+    "vernacular": "Cinamwanga",
+    "script": "ROMAN",
+    "name": "Cinamwanga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CIN",
+    "locale": "nya",
+    "vernacular": "Cinyanja",
+    "script": "ROMAN",
+    "name": "Cinyanja",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CMK",
+    "locale": "cfg",
+    "vernacular": "Como Karim",
+    "script": "ROMAN",
+    "name": "Como Karim",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CMG",
+    "locale": "zdj",
+    "vernacular": "Shikomori (Ngazidja)",
+    "script": "ROMAN",
+    "name": "Comorian (Ngazidja)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "COR",
+    "locale": "crn",
+    "vernacular": "cora (el nayar)",
+    "script": "ROMAN",
+    "name": "Cora (El Nayar)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CSC",
+    "locale": "co",
+    "vernacular": "Corsu",
+    "script": "ROMAN",
+    "name": "Corsican",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CY",
+    "locale": "crk_latn",
+    "vernacular": "nēhiyawēwin",
+    "script": "ROMAN",
+    "name": "Cree Plains (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CYS",
+    "locale": "crk_x_cys",
+    "vernacular": "ᓀᐦᐃᔭᐁᐧᐃᐧᐣ",
+    "script": "CANADIAN_SY",
+    "name": "Cree Plains (Syllabics)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CSR",
+    "locale": "crj_latn",
+    "vernacular": "Iinuuayimuwin",
+    "script": "ROMAN",
+    "name": "Cree Southern East (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YC",
+    "locale": "csw_x_yc",
+    "vernacular": "Ininîmowin",
+    "script": "ROMAN",
+    "name": "Cree West Swampy (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YCS",
+    "locale": "csw_x_ycs",
+    "vernacular": "ᐃᓂᓃᒧᐏᐣ",
+    "script": "CANADIAN_SY",
+    "name": "Cree West Swampy (Syllabics)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CTR",
+    "locale": "crh_x_ctr",
+    "vernacular": "Қрим-тотор",
+    "script": "ROMAN",
+    "name": "Crimean Tatar",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CTC",
+    "locale": "crh_x_ctc",
+    "vernacular": "къырымтатар (кирилл)",
+    "script": "CYRILLIC",
+    "name": "Crimean Tatar (Cyrillic)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CBE",
+    "locale": "cub",
+    "vernacular": "Cubeo",
+    "script": "ROMAN",
+    "name": "Cubeo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CPC",
+    "locale": "kpc",
+    "vernacular": "Curripaco",
+    "script": "ROMAN",
+    "name": "Curripaco",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "B",
+    "locale": "cs",
+    "vernacular": "čeština",
+    "script": "ROMAN",
+    "name": "Czech",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CSE",
+    "locale": "cse",
+    "vernacular": "český znakový jazyk",
+    "script": "ROMAN",
+    "name": "Czech Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "DGA",
+    "locale": "dga",
+    "vernacular": "Dagaare",
+    "script": "ROMAN",
+    "name": "Dagaare",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DGB",
+    "locale": "dag",
+    "vernacular": "Dagbanli",
+    "script": "ROMAN",
+    "name": "Dagbani",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DT",
+    "locale": "dak",
+    "vernacular": "Dakota",
+    "script": "ROMAN",
+    "name": "Dakota",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DMR",
+    "locale": "naq_x_dmr",
+    "vernacular": "Damara",
+    "script": "ROMAN",
+    "name": "Damara",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DG",
+    "locale": "ada",
+    "vernacular": "Dangme",
+    "script": "ROMAN",
+    "name": "Dangme",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "D",
+    "locale": "da",
+    "vernacular": "Dansk",
+    "script": "ROMAN",
+    "name": "Danish",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DSL",
+    "locale": "dsl",
+    "vernacular": "Dansk tegnsprog",
+    "script": "ROMAN",
+    "name": "Danish Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "DRG",
+    "locale": "dar",
+    "vernacular": "дарган",
+    "script": "CYRILLIC",
+    "name": "Dargwa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DAR",
+    "locale": "prs",
+    "vernacular": "دری",
+    "script": "ARABIC",
+    "name": "Dari",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "DKA",
+    "locale": "knx",
+    "vernacular": "Dayak Ahe",
+    "script": "ROMAN",
+    "name": "Dayak Ahe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DK",
+    "locale": "nij",
+    "vernacular": "Dayak Ngaju",
+    "script": "ROMAN",
+    "name": "Dayak Ngaju",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DKS",
+    "locale": "sya",
+    "vernacular": "Dayak Siang",
+    "script": "ROMAN",
+    "name": "Dayak Siang",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DYT",
+    "locale": "xdy",
+    "vernacular": "Dayak Tomun",
+    "script": "ROMAN",
+    "name": "Dayak Tomun",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DND",
+    "locale": "ddn",
+    "vernacular": "Dendi",
+    "script": "ROMAN",
+    "name": "Dendi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DNS",
+    "locale": "dez",
+    "vernacular": "Londengese",
+    "script": "ROMAN",
+    "name": "Dengese",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DDL",
+    "locale": "dic",
+    "vernacular": "Dida (Lakota)",
+    "script": "ROMAN",
+    "name": "Dida (Lakota)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DGR",
+    "locale": "os_x_dgr",
+    "vernacular": "дигорон",
+    "script": "CYRILLIC",
+    "name": "Digor",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DI",
+    "locale": "din",
+    "vernacular": "Dinka",
+    "script": "ROMAN",
+    "name": "Dinka",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DO",
+    "locale": "dyo",
+    "vernacular": "Jóola",
+    "script": "ROMAN",
+    "name": "Diola",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DTM",
+    "locale": "tbz",
+    "vernacular": "Ditammari",
+    "script": "ROMAN",
+    "name": "Ditammari",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DTS",
+    "locale": "dts",
+    "vernacular": "Dɔgɔn (Tɔrɔ Sɔ)",
+    "script": "ROMAN",
+    "name": "Dogon (Toro So)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DA",
+    "locale": "dua",
+    "vernacular": "Douala",
+    "script": "ROMAN",
+    "name": "Douala",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LF",
+    "locale": "dhv",
+    "vernacular": "Drehu",
+    "script": "ROMAN",
+    "name": "Drehu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DGN",
+    "locale": "dng",
+    "vernacular": "Dungan",
+    "script": "CYRILLIC",
+    "name": "Dungan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KAD",
+    "locale": "dtp",
+    "vernacular": "Dusun",
+    "script": "ROMAN",
+    "name": "Dusun",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OBG",
+    "locale": "nl_be",
+    "vernacular": "Nederlands (België)",
+    "script": "ROMAN",
+    "name": "Dutch (Belgium)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OSR",
+    "locale": "nl_sr",
+    "vernacular": "Nederlands (Suriname)",
+    "script": "ROMAN",
+    "name": "Dutch (Suriname)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DZR",
+    "locale": "dzo_latn",
+    "vernacular": "Dzongkha (Roman)",
+    "script": "ROMAN",
+    "name": "Dzongkha (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DZ",
+    "locale": "dzo_tibt",
+    "vernacular": "Dzongkha (Tibetan)",
+    "script": "TIBETAN",
+    "name": "Dzongkha (Tibetan)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "EBA",
+    "locale": "igb",
+    "vernacular": "Ebira",
+    "script": "ROMAN",
+    "name": "Ebira",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ED",
+    "locale": "bin",
+    "vernacular": "Edo",
+    "script": "ROMAN",
+    "name": "Edo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "EFN",
+    "locale": "llp",
+    "vernacular": "Efate (North)",
+    "script": "ROMAN",
+    "name": "Efate (North)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "EFS",
+    "locale": "erk",
+    "vernacular": "Efate (South)",
+    "script": "ROMAN",
+    "name": "Efate (South)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "EF",
+    "locale": "efi",
+    "vernacular": "Efịk",
+    "script": "ROMAN",
+    "name": "Efik",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "EMB",
+    "locale": "cto",
+    "vernacular": "embera katio",
+    "script": "ROMAN",
+    "name": "Emberá (Catío)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "EMC",
+    "locale": "cmi",
+    "vernacular": "ẽbẽra beɗea chamí",
+    "script": "ROMAN",
+    "name": "Emberá (Chamí)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "EMP",
+    "locale": "emp",
+    "vernacular": "Emberá dóbida",
+    "script": "ROMAN",
+    "name": "Emberá (Northern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ENG",
+    "locale": "en_ng",
+    "vernacular": "English (Nigeria)",
+    "script": "ROMAN",
+    "name": "English (Nigeria)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "EZ",
+    "locale": "myv",
+    "vernacular": "эрзянь",
+    "script": "CYRILLIC",
+    "name": "Erzya",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IH",
+    "locale": "ish",
+    "vernacular": "Esan",
+    "script": "ROMAN",
+    "name": "Esan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ST",
+    "locale": "et",
+    "vernacular": "eesti",
+    "script": "ROMAN",
+    "name": "Estonian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "STD",
+    "locale": "eso",
+    "vernacular": "eesti viipekeel",
+    "script": "ROMAN",
+    "name": "Estonian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "ESL",
+    "locale": "eth",
+    "vernacular": "የኢትዮጵያ ምልክት ቋንቋ",
+    "script": "ETHIOPIC",
+    "name": "Ethiopian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "ETN",
+    "locale": "eto",
+    "vernacular": "Iton",
+    "script": "ROMAN",
+    "name": "Eton",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "EW",
+    "locale": "ee",
+    "vernacular": "Eʋegbe",
+    "script": "ROMAN",
+    "name": "Ewe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "EWN",
+    "locale": "ewo",
+    "vernacular": "Ewondo",
+    "script": "ROMAN",
+    "name": "Ewondo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FGN",
+    "locale": "fan",
+    "vernacular": "Fang",
+    "script": "ROMAN",
+    "name": "Fang",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FA",
+    "locale": "fat",
+    "vernacular": "Mfantse",
+    "script": "ROMAN",
+    "name": "Fante",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FR",
+    "locale": "fo",
+    "vernacular": "Føroyskt",
+    "script": "ROMAN",
+    "name": "Faroese",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FTL",
+    "locale": "ddg",
+    "vernacular": "Fataluku",
+    "script": "ROMAN",
+    "name": "Fataluku",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FFE",
+    "locale": "fmp",
+    "vernacular": "Bafang",
+    "script": "ROMAN",
+    "name": "Fe'fe'",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FJS",
+    "locale": "sgn_fj",
+    "vernacular": "Fiji Sign Language",
+    "script": "ROMAN",
+    "name": "Fiji Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "FN",
+    "locale": "fj",
+    "vernacular": "vakaViti",
+    "script": "ROMAN",
+    "name": "Fijian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FSL",
+    "locale": "psp",
+    "vernacular": "Filipino Sign Language",
+    "script": "ROMAN",
+    "name": "Filipino Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "VGT",
+    "locale": "vgt",
+    "vernacular": "Vlaamse Gebarentaal",
+    "script": "ROMAN",
+    "name": "Flemish Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "FO",
+    "locale": "fon",
+    "vernacular": "Fɔngbe",
+    "script": "ROMAN",
+    "name": "Fon",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FF",
+    "locale": "gur",
+    "vernacular": "Farefare",
+    "script": "ROMAN",
+    "name": "Frafra",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FCD",
+    "locale": "fr_cl",
+    "vernacular": "Français Ivoirien",
+    "script": "ROMAN",
+    "name": "Français Ivoirien",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FBN",
+    "locale": "fr_bj",
+    "vernacular": "Français (Bénin)",
+    "script": "ROMAN",
+    "name": "French (Benin)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FCA",
+    "locale": "fr_ca",
+    "vernacular": "Français (Canada)",
+    "script": "ROMAN",
+    "name": "French (Canada)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FS",
+    "locale": "fy",
+    "vernacular": "Frysk",
+    "script": "ROMAN",
+    "name": "Frisian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FD",
+    "locale": "fub",
+    "vernacular": "Fulfulde (Kamerun)",
+    "script": "ROMAN",
+    "name": "Fulfulde (Cameroon)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FLN",
+    "locale": "fuv",
+    "vernacular": "Fulfulde (Nigerian)",
+    "script": "ROMAN",
+    "name": "Fulfulde (Nigerian)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FT",
+    "locale": "fud",
+    "vernacular": "Fakafutuna",
+    "script": "ROMAN",
+    "name": "Futuna (East)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FW",
+    "locale": "fwa",
+    "vernacular": "Fwâi",
+    "script": "ROMAN",
+    "name": "Fwâi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GA",
+    "locale": "gaa",
+    "vernacular": "Ga",
+    "script": "ROMAN",
+    "name": "Ga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GZ",
+    "locale": "gag_x_gz",
+    "vernacular": "гaгaуз",
+    "script": "CYRILLIC",
+    "name": "Gagauz",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GZR",
+    "locale": "gag_x_gzr",
+    "vernacular": "gagauz (latin)",
+    "script": "ROMAN",
+    "name": "Gagauz (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GLC",
+    "locale": "gl",
+    "vernacular": "Galego",
+    "script": "ROMAN",
+    "name": "Galician",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GRW",
+    "locale": "gbm",
+    "vernacular": "गढ़वाली",
+    "script": "DEVANAGARI",
+    "name": "Garhwali",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GRF",
+    "locale": "cab",
+    "vernacular": "Garifuna",
+    "script": "ROMAN",
+    "name": "Garifuna",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GAR",
+    "locale": "grt_x_gar",
+    "vernacular": "গারো (আবেং)",
+    "script": "BENGALI",
+    "name": "Garo (Abeng)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GBA",
+    "locale": "gba",
+    "vernacular": "Gbaya",
+    "script": "ROMAN",
+    "name": "Gbaya",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GDE",
+    "locale": "jw_gde",
+    "vernacular": "Gede'uffa",
+    "script": "ROMAN",
+    "name": "Gedeo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GE",
+    "locale": "ka",
+    "vernacular": "ქართული",
+    "script": "GEORGIAN",
+    "name": "Georgian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GGS",
+    "locale": "sgn_ge",
+    "vernacular": "ქართული ჟესტური ენა",
+    "script": "GEORGIAN",
+    "name": "Georgian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "GHS",
+    "locale": "gse",
+    "vernacular": "Ghanaian Sign Language",
+    "script": "ROMAN",
+    "name": "Ghanaian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "GHM",
+    "locale": "bbj",
+    "vernacular": "Bandjoun-Baham",
+    "script": "ROMAN",
+    "name": "Ghomálá’",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GY",
+    "locale": "nyf",
+    "vernacular": "Giryama",
+    "script": "ROMAN",
+    "name": "Giryama",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GTN",
+    "locale": "toh",
+    "vernacular": "Gitonga",
+    "script": "ROMAN",
+    "name": "Gitonga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GG",
+    "locale": "gog",
+    "vernacular": "Cigogo",
+    "script": "ROMAN",
+    "name": "Gogo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GN",
+    "locale": "gkn",
+    "vernacular": "Gokana",
+    "script": "ROMAN",
+    "name": "Gokana",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GRC",
+    "locale": "gux",
+    "vernacular": "Gulmancema",
+    "script": "ROMAN",
+    "name": "Gourmanchéma",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GO",
+    "locale": "goa",
+    "vernacular": "Goro",
+    "script": "ROMAN",
+    "name": "Gouro",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GRB",
+    "locale": "grb",
+    "vernacular": "Grebo",
+    "script": "ROMAN",
+    "name": "Grebo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "G",
+    "locale": "el",
+    "vernacular": "Ελληνική",
+    "script": "GREEK",
+    "name": "Greek",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GSL",
+    "locale": "gss",
+    "vernacular": "Ελληνική Νοηματική Γλώσσα",
+    "script": "GREEK",
+    "name": "Greek Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "GL",
+    "locale": "kl",
+    "vernacular": "Kalaallisut",
+    "script": "ROMAN",
+    "name": "Greenlandic",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GLE",
+    "locale": "kl_x_gle",
+    "vernacular": "Tunumiisut",
+    "script": "ROMAN",
+    "name": "Greenlandic (East)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GCR",
+    "locale": "gcf",
+    "vernacular": "Kréyòl Gwadloup",
+    "script": "ROMAN",
+    "name": "Guadeloupean Creole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GHB",
+    "locale": "guh",
+    "vernacular": "guahibo",
+    "script": "ROMAN",
+    "name": "Guahibo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GBM",
+    "locale": "gum",
+    "vernacular": "Namtrik",
+    "script": "ROMAN",
+    "name": "Guambiano",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GI",
+    "locale": "gug",
+    "vernacular": "guarani",
+    "script": "ROMAN",
+    "name": "Guarani",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GIB",
+    "locale": "gui",
+    "vernacular": "Guaraní boliviano",
+    "script": "ROMAN",
+    "name": "Guarani (Bolivia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GIM",
+    "locale": "gun",
+    "vernacular": "Guaraní (Mbyá)",
+    "script": "ROMAN",
+    "name": "Guaraní (Mbyá)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GRY",
+    "locale": "gyr",
+    "vernacular": "Guarayu",
+    "script": "ROMAN",
+    "name": "Guarayu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GBR",
+    "locale": "guo",
+    "vernacular": "jiw",
+    "script": "ROMAN",
+    "name": "Guayabero",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GRZ",
+    "locale": "gkp",
+    "vernacular": "Kpɛlɛɛwoo",
+    "script": "ROMAN",
+    "name": "Guerze",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GNC",
+    "locale": "gcr",
+    "vernacular": "Kréyòl gwiyanè",
+    "script": "ROMAN",
+    "name": "Guianese Creole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GU",
+    "locale": "gu",
+    "vernacular": "ગુજરાતી",
+    "script": "GUJARATI",
+    "name": "Gujarati",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "EG",
+    "locale": "guw",
+    "vernacular": "Gungbe",
+    "script": "ROMAN",
+    "name": "Gun",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "UN",
+    "locale": "cuk",
+    "vernacular": "dule",
+    "script": "ROMAN",
+    "name": "Guna",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GCE",
+    "locale": "gyn",
+    "vernacular": "Guyanese Creole English",
+    "script": "ROMAN",
+    "name": "Guyanese Creole English",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GUR",
+    "locale": "gxx",
+    "vernacular": "wɛ",
+    "script": "ROMAN",
+    "name": "Guéré",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HDY",
+    "locale": "hdy",
+    "vernacular": "Hadiyya",
+    "script": "ROMAN",
+    "name": "Hadiyya",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CR",
+    "locale": "ht",
+    "vernacular": "Kreyòl ayisyen",
+    "script": "ROMAN",
+    "name": "Haitian Creole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HKI",
+    "locale": "hak_id",
+    "vernacular": "Cina Khek (Indonesia)",
+    "script": "ROMAN",
+    "name": "Hakka (Indonesia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CHH",
+    "locale": "hak",
+    "vernacular": "客家話（台灣）",
+    "script": "CHINESE",
+    "name": "Hakka (Taiwan)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HLA",
+    "locale": "hla",
+    "vernacular": "Halia",
+    "script": "ROMAN",
+    "name": "Halia",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HMA",
+    "locale": "hyw_x_hma",
+    "vernacular": "համշեներեն (հայերեն)",
+    "script": "ARMENIAN",
+    "name": "Hamshen (Armenian)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HMS",
+    "locale": "hyw_x_hms",
+    "vernacular": "һамшенерен (кирилица)",
+    "script": "CYRILLIC",
+    "name": "Hamshen (Cyrillic)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HNO",
+    "locale": "lml",
+    "vernacular": "Hano",
+    "script": "ROMAN",
+    "name": "Hano",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HRV",
+    "locale": "bgc",
+    "vernacular": "हरियाण्वी",
+    "script": "DEVANAGARI",
+    "name": "Haryanvi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HA",
+    "locale": "ha",
+    "vernacular": "Hausa",
+    "script": "ROMAN",
+    "name": "Hausa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HVU",
+    "locale": "hav",
+    "vernacular": "Ekihavu",
+    "script": "ROMAN",
+    "name": "Havu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HW",
+    "locale": "haw",
+    "vernacular": "ʻŌlelo Hawaiʻi",
+    "script": "ROMAN",
+    "name": "Hawaiian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HWP",
+    "locale": "hwc",
+    "vernacular": "Hawai’i Pidgin",
+    "script": "ROMAN",
+    "name": "Hawai’i Pidgin",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HWU",
+    "locale": "hvn",
+    "vernacular": "Sabu",
+    "script": "ROMAN",
+    "name": "Hawu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HY",
+    "locale": "hay",
+    "vernacular": "Ekihaya",
+    "script": "ROMAN",
+    "name": "Haya",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "Q",
+    "locale": "he",
+    "vernacular": "עברית",
+    "script": "HEBREW",
+    "name": "Hebrew",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "HH",
+    "locale": "heh",
+    "vernacular": "Kihehe",
+    "script": "ROMAN",
+    "name": "Hehe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HR",
+    "locale": "hz",
+    "vernacular": "Otjiherero",
+    "script": "ROMAN",
+    "name": "Herero",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HV",
+    "locale": "hil",
+    "vernacular": "Hiligaynon",
+    "script": "ROMAN",
+    "name": "Hiligaynon",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HI",
+    "locale": "hi",
+    "vernacular": "हिंदी",
+    "script": "DEVANAGARI",
+    "name": "Hindi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HFJ",
+    "locale": "hif",
+    "vernacular": "Hindi (Fiji)",
+    "script": "ROMAN",
+    "name": "Hindi (Fiji)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HRM",
+    "locale": "hi_latn",
+    "vernacular": "Hindi (Roman)",
+    "script": "ROMAN",
+    "name": "Hindi (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MO",
+    "locale": "ho",
+    "vernacular": "Hiri Motu",
+    "script": "ROMAN",
+    "name": "Hiri Motu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MCG",
+    "locale": "mbn",
+    "vernacular": "Jitnu",
+    "script": "ROMAN",
+    "name": "Hitnu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HMN",
+    "locale": "hnj",
+    "vernacular": "Moob Ntsuab",
+    "script": "ROMAN",
+    "name": "Hmong (Green)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HM",
+    "locale": "hmn",
+    "vernacular": "Hmoob Dawb",
+    "script": "ROMAN",
+    "name": "Hmong (White)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HSL",
+    "locale": "hks",
+    "vernacular": "香港手語",
+    "script": "CHINESE",
+    "name": "Hong Kong Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "HPI",
+    "locale": "hop",
+    "vernacular": "Hopi",
+    "script": "ROMAN",
+    "name": "Hopi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HST",
+    "locale": "hus",
+    "vernacular": "tének",
+    "script": "ROMAN",
+    "name": "Huastec (San Luis Potosi)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HSV",
+    "locale": "hus_x_hsv",
+    "vernacular": "tének de Veracruz",
+    "script": "ROMAN",
+    "name": "Huastec (Veracruz)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HUV",
+    "locale": "huv",
+    "vernacular": "ombeayiiüts",
+    "script": "ROMAN",
+    "name": "Huave (San Mateo del Mar)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HU",
+    "locale": "hul",
+    "vernacular": "Vula’a",
+    "script": "ROMAN",
+    "name": "Hula",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "H",
+    "locale": "hu",
+    "vernacular": "magyar",
+    "script": "ROMAN",
+    "name": "Hungarian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HDF",
+    "locale": "hsh",
+    "vernacular": "magyar jelnyelv",
+    "script": "ROMAN",
+    "name": "Hungarian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "HSK",
+    "locale": "hrx",
+    "vernacular": "Hunsrik",
+    "script": "ROMAN",
+    "name": "Hunsrik",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HTX",
+    "locale": "geh",
+    "vernacular": "Hutterite German",
+    "script": "ROMAN",
+    "name": "Hutterite German",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IAA",
+    "locale": "iai",
+    "vernacular": "Iaai",
+    "script": "ROMAN",
+    "name": "Iaai",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IBL",
+    "locale": "ibl",
+    "vernacular": "Ibaloi",
+    "script": "ROMAN",
+    "name": "Ibaloi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IA",
+    "locale": "iba",
+    "vernacular": "Iban",
+    "script": "ROMAN",
+    "name": "Iban",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IG",
+    "locale": "ibg",
+    "vernacular": "Ibanag",
+    "script": "ROMAN",
+    "name": "Ibanag",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IBI",
+    "locale": "yom_x_ibi",
+    "vernacular": "Ibinda",
+    "script": "ROMAN",
+    "name": "Ibinda",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IC",
+    "locale": "is",
+    "vernacular": "íslenska",
+    "script": "ROMAN",
+    "name": "Icelandic",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ID",
+    "locale": "idu",
+    "vernacular": "Idoma",
+    "script": "ROMAN",
+    "name": "Idoma",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AA",
+    "locale": "igl",
+    "vernacular": "Igala",
+    "script": "ROMAN",
+    "name": "Igala",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IB",
+    "locale": "ig",
+    "vernacular": "Igbo",
+    "script": "ROMAN",
+    "name": "Igbo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IGE",
+    "locale": "ige",
+    "vernacular": "Igede",
+    "script": "ROMAN",
+    "name": "Igede",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IGN",
+    "locale": "ign",
+    "vernacular": "Ignaciano",
+    "script": "ROMAN",
+    "name": "Ignaciano",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IJ",
+    "locale": "ijc",
+    "vernacular": "Ijaw",
+    "script": "ROMAN",
+    "name": "Ijaw",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IL",
+    "locale": "ilo",
+    "vernacular": "Iloko",
+    "script": "ROMAN",
+    "name": "Iloko",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IKN",
+    "locale": "akl",
+    "vernacular": "Inakeanon",
+    "script": "ROMAN",
+    "name": "Inakeanon",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "INS",
+    "locale": "ins",
+    "vernacular": "Indian Sign Language",
+    "script": "ROMAN",
+    "name": "Indian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "IN",
+    "locale": "id",
+    "vernacular": "Indonesia",
+    "script": "ROMAN",
+    "name": "Indonesian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "INI",
+    "locale": "inl",
+    "vernacular": "Bahasa Isyarat Indonesia",
+    "script": "ROMAN",
+    "name": "Indonesian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "INB",
+    "locale": "inb",
+    "vernacular": "Inga",
+    "script": "ROMAN",
+    "name": "Inga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IUR",
+    "locale": "iu_latn",
+    "vernacular": "Inuktitut",
+    "script": "ROMAN",
+    "name": "Inuktitut (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IU",
+    "locale": "iu",
+    "vernacular": "ᐃᓄᒃᑎᑐᑦ (ᖃᓂᐅᔮᖅᐸᐃᑦ)",
+    "script": "CANADIAN_SY",
+    "name": "Inuktitut (Syllabics)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GC",
+    "locale": "ga",
+    "vernacular": "Gaeilge",
+    "script": "ROMAN",
+    "name": "Irish",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CRE",
+    "locale": "icr",
+    "vernacular": "San Andrés Creole",
+    "script": "ROMAN",
+    "name": "Islander Creole English",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IS",
+    "locale": "iso",
+    "vernacular": "Isoko",
+    "script": "ROMAN",
+    "name": "Isoko",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QSL",
+    "locale": "isr",
+    "vernacular": "שפת סימנים ישראלית",
+    "script": "HEBREW",
+    "name": "Israeli Sign Language",
+    "isSignLanguage": true,
+    "isRTL": true
+  },
+  {
+    "code": "I",
+    "locale": "it",
+    "vernacular": "Italiano",
+    "script": "ROMAN",
+    "name": "Italian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ISL",
+    "locale": "ise",
+    "vernacular": "Lingua dei segni italiana",
+    "script": "ROMAN",
+    "name": "Italian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "ITW",
+    "locale": "itv",
+    "vernacular": "Itawit",
+    "script": "ROMAN",
+    "name": "Itawit",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IT",
+    "locale": "its",
+    "vernacular": "Itsekiri",
+    "script": "ROMAN",
+    "name": "Itsekiri",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IMN",
+    "locale": "ium",
+    "vernacular": "Iu-Mienh",
+    "script": "ROMAN",
+    "name": "Iu Mien",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "IXL",
+    "locale": "ixl",
+    "vernacular": "ixil",
+    "script": "ROMAN",
+    "name": "Ixil",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "JCR",
+    "locale": "jam_x_jcr",
+    "vernacular": "Patwa",
+    "script": "ROMAN",
+    "name": "Jamaican Creole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "J",
+    "locale": "ja",
+    "vernacular": "日本語",
+    "script": "JAPANESE",
+    "name": "Japanese",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "JSL",
+    "locale": "jsl",
+    "vernacular": "日本手話",
+    "script": "JAPANESE",
+    "name": "Japanese Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "JAR",
+    "locale": "jra",
+    "vernacular": "Jarai",
+    "script": "ROMAN",
+    "name": "Jarai",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "JA",
+    "locale": "jv",
+    "vernacular": "Jawa",
+    "script": "ROMAN",
+    "name": "Javanese",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "JVN",
+    "locale": "jav",
+    "vernacular": "Jawa Timur",
+    "script": "ROMAN",
+    "name": "Javanese (Eastern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "JJU",
+    "locale": "jje",
+    "vernacular": "제주어",
+    "script": "KOREAN",
+    "name": "Jejueo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "JWK",
+    "locale": "whg",
+    "vernacular": "Jiwaka Yu",
+    "script": "ROMAN",
+    "name": "Jiwaka",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "JL",
+    "locale": "dyu",
+    "vernacular": "Jula",
+    "script": "ROMAN",
+    "name": "Jula",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KBR",
+    "locale": "kbd",
+    "vernacular": "адыгэбзэ",
+    "script": "CYRILLIC",
+    "name": "Kabardin-Cherkess",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KAB",
+    "locale": "kbp",
+    "vernacular": "Kabɩyɛ",
+    "script": "ROMAN",
+    "name": "Kabiye",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KBV",
+    "locale": "kea",
+    "vernacular": "Kabuverdianu",
+    "script": "ROMAN",
+    "name": "Kabuverdianu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KBT",
+    "locale": "kea_x_kbt",
+    "vernacular": "Kabuverdianu (Barlaventu)",
+    "script": "ROMAN",
+    "name": "Kabuverdianu (Barlaventu)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KBY",
+    "locale": "kab",
+    "vernacular": "Taqbaylit",
+    "script": "ROMAN",
+    "name": "Kabyle",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AH",
+    "locale": "kac",
+    "vernacular": "Kachin",
+    "script": "ROMAN",
+    "name": "Kachin",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KDV",
+    "locale": "fij_x_kdv",
+    "vernacular": "Kadavu",
+    "script": "ROMAN",
+    "name": "Kadavu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KAZ",
+    "locale": "kzj",
+    "vernacular": "Kadazan",
+    "script": "ROMAN",
+    "name": "Kadazan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KGG",
+    "locale": "kgp",
+    "vernacular": "kaingang",
+    "script": "ROMAN",
+    "name": "Kaingang",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KAA",
+    "locale": "kgk",
+    "vernacular": "Kaiwá",
+    "script": "ROMAN",
+    "name": "Kaiwá",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KL",
+    "locale": "kck_x_kl",
+    "vernacular": "Kalanga (Botswana)",
+    "script": "ROMAN",
+    "name": "Kalanga (Botswana)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KLZ",
+    "locale": "kck_x_klz",
+    "vernacular": "Kalanga (Zimbabwe)",
+    "script": "ROMAN",
+    "name": "Kalanga (Zimbabwe)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KJ",
+    "locale": "kln",
+    "vernacular": "Kalenjin",
+    "script": "ROMAN",
+    "name": "Kalenjin",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KLK",
+    "locale": "xal",
+    "vernacular": "хальмг",
+    "script": "CYRILLIC",
+    "name": "Kalmyk",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KMY",
+    "locale": "kyk",
+    "vernacular": "Kamayo",
+    "script": "ROMAN",
+    "name": "Kamayo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KB",
+    "locale": "kam",
+    "vernacular": "Kikamba",
+    "script": "ROMAN",
+    "name": "Kamba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KMB",
+    "locale": "xbr",
+    "vernacular": "Kambera (Sumba Timur)",
+    "script": "ROMAN",
+    "name": "Kambera",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KMW",
+    "locale": "hig",
+    "vernacular": "Kamwe",
+    "script": "ROMAN",
+    "name": "Kamwe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KGH",
+    "locale": "xnr",
+    "vernacular": "कंगड़ी (हमीरपुरी)",
+    "script": "DEVANAGARI",
+    "name": "Kangri (Hamirpuri)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KNY",
+    "locale": "kne",
+    "vernacular": "Kankanaey",
+    "script": "ROMAN",
+    "name": "Kankanaey",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KA",
+    "locale": "kn",
+    "vernacular": "ಕನ್ನಡ",
+    "script": "KANNADA",
+    "name": "Kannada",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KYK",
+    "locale": "kny",
+    "vernacular": "Ciin-kanyok",
+    "script": "ROMAN",
+    "name": "Kanyok",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BAL",
+    "locale": "krc",
+    "vernacular": "къарачай-малкъар",
+    "script": "CYRILLIC",
+    "name": "Karachay-Balkar",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KRK",
+    "locale": "kaa",
+    "vernacular": "қарақалпақ",
+    "script": "CYRILLIC",
+    "name": "Karakalpak",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KPN",
+    "locale": "pww",
+    "vernacular": "โผล่ง",
+    "script": "THAI",
+    "name": "Karen (Pwo Northern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PK",
+    "locale": "pwo",
+    "vernacular": "Karen (Pwo Western)",
+    "script": "MYANMAR",
+    "name": "Karen (Pwo Western)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KR",
+    "locale": "ksw",
+    "vernacular": "ကညီ(စှီၤ)ကျိာ်",
+    "script": "MYANMAR",
+    "name": "Karen (S'gaw)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KSM",
+    "locale": "xsm",
+    "vernacular": "Kasem",
+    "script": "ROMAN",
+    "name": "Kasem",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KSH",
+    "locale": "csb",
+    "vernacular": "kaszëbsczi",
+    "script": "ROMAN",
+    "name": "Kashubian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AZ",
+    "locale": "kk",
+    "vernacular": "қазақ",
+    "script": "CYRILLIC",
+    "name": "Kazakh",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AZA",
+    "locale": "kk_arab",
+    "vernacular": "قازاق ٴتىلى (ارابشا جازۋى)",
+    "script": "ARABIC",
+    "name": "Kazakh (Arabic)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "KEI",
+    "locale": "kei",
+    "vernacular": "Kei",
+    "script": "ROMAN",
+    "name": "Kei",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GK",
+    "locale": "kek",
+    "vernacular": "q’eqchi’",
+    "script": "ROMAN",
+    "name": "Kekchi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KSI",
+    "locale": "xki",
+    "vernacular": "Kenyan Sign Language",
+    "script": "ROMAN",
+    "name": "Kenyan Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "KHK",
+    "locale": "kjh",
+    "vernacular": "хакас",
+    "script": "CYRILLIC",
+    "name": "Khakass",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OG",
+    "locale": "ogo",
+    "vernacular": "Khana",
+    "script": "ROMAN",
+    "name": "Khana",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KHL",
+    "locale": "hin_x_khl",
+    "vernacular": "Khari Boli",
+    "script": "ROMAN",
+    "name": "Khari Boli",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KS",
+    "locale": "kha",
+    "vernacular": "Khasi",
+    "script": "ROMAN",
+    "name": "Khasi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KMN",
+    "locale": "kxm",
+    "vernacular": "ขแมร์เสียม",
+    "script": "THAI",
+    "name": "Khmer (Northern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KBL",
+    "locale": "blv",
+    "vernacular": "Kibala",
+    "script": "ROMAN",
+    "name": "Kibala",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KFL",
+    "locale": "flr",
+    "vernacular": "Kifuliiru",
+    "script": "ROMAN",
+    "name": "Kifuliiru",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KHB",
+    "locale": "hem",
+    "vernacular": "Kihemba",
+    "script": "ROMAN",
+    "name": "Kihemba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KD",
+    "locale": "kqn",
+    "vernacular": "Kikaonde",
+    "script": "ROMAN",
+    "name": "Kikaonde",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KG",
+    "locale": "kwy",
+    "vernacular": "Kikongo",
+    "script": "ROMAN",
+    "name": "Kikongo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KGL",
+    "locale": "ktu_x_kgl",
+    "vernacular": "Kikongo ya leta",
+    "script": "ROMAN",
+    "name": "Kikongo ya Leta",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KQ",
+    "locale": "ki",
+    "vernacular": "Gĩkũyũ",
+    "script": "ROMAN",
+    "name": "Kikuyu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KU",
+    "locale": "lu",
+    "vernacular": "Kiluba",
+    "script": "ROMAN",
+    "name": "Kiluba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MNN",
+    "locale": "kg_x_mnn",
+    "vernacular": "Kimanianga",
+    "script": "ROMAN",
+    "name": "Kimanyanga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KIM",
+    "locale": "kmb",
+    "vernacular": "Kimbundu",
+    "script": "ROMAN",
+    "name": "Kimbundu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KIN",
+    "locale": "nnb",
+    "vernacular": "Kinande",
+    "script": "ROMAN",
+    "name": "Kinande",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KNR",
+    "locale": "krj",
+    "vernacular": "Kinaray-a",
+    "script": "ROMAN",
+    "name": "Kinaray-a",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KK",
+    "locale": "nyy_x_kk",
+    "vernacular": "Kinyakyusa",
+    "script": "ROMAN",
+    "name": "Kinyakyusa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YW",
+    "locale": "rw",
+    "vernacular": "Ikinyarwanda",
+    "script": "ROMAN",
+    "name": "Kinyarwanda",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KIP",
+    "locale": "pem",
+    "vernacular": "Kipende",
+    "script": "ROMAN",
+    "name": "Kipende",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KZ",
+    "locale": "ky",
+    "vernacular": "кыргыз",
+    "script": "CYRILLIC",
+    "name": "Kirghiz",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GB",
+    "locale": "gil",
+    "vernacular": "Kiribati",
+    "script": "ROMAN",
+    "name": "Kiribati",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RU",
+    "locale": "run",
+    "vernacular": "Ikirundi",
+    "script": "ROMAN",
+    "name": "Kirundi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KI",
+    "locale": "kss",
+    "vernacular": "Kisiei",
+    "script": "ROMAN",
+    "name": "Kisi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "II",
+    "locale": "guz",
+    "vernacular": "Kisii",
+    "script": "ROMAN",
+    "name": "Kisii",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KSN",
+    "locale": "sop",
+    "vernacular": "Kisongye",
+    "script": "ROMAN",
+    "name": "Kisonge",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KIT",
+    "locale": "ktu_x_kit",
+    "vernacular": "Kituba",
+    "script": "ROMAN",
+    "name": "Kituba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KBK",
+    "locale": "trp",
+    "vernacular": "Kokborok",
+    "script": "ROMAN",
+    "name": "Kokborok",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KKL",
+    "locale": "kzn",
+    "vernacular": "Kokola",
+    "script": "ROMAN",
+    "name": "Kokola",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KM",
+    "locale": "kpv",
+    "vernacular": "коми",
+    "script": "CYRILLIC",
+    "name": "Komi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KMP",
+    "locale": "koi",
+    "vernacular": "коми-пермяцкӧй",
+    "script": "CYRILLIC",
+    "name": "Komi-Permyak",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MK",
+    "locale": "kg",
+    "vernacular": "Kikongo (Rép. dém. du congo)",
+    "script": "ROMAN",
+    "name": "Kongo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BRS",
+    "locale": "sgn_bi",
+    "vernacular": "Langue des signes burundaise",
+    "script": "ROMAN",
+    "name": "Burundi Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "CGS",
+    "locale": "sgn_cd",
+    "vernacular": "Langue des signes congolaise",
+    "script": "ROMAN",
+    "name": "Congolese Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "KND",
+    "locale": "kex",
+    "vernacular": "कोंकणी (देवनागरी)",
+    "script": "DEVANAGARI",
+    "name": "Konkani (Devanagari)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KN",
+    "locale": "knn",
+    "vernacular": "ಕೊಂಕಣಿ (ಕನ್ನಡ)",
+    "script": "KANNADA",
+    "name": "Konkani (Kannada)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KT",
+    "locale": "gom",
+    "vernacular": "Konkani (Romi)",
+    "script": "ROMAN",
+    "name": "Konkani (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KKB",
+    "locale": "xon",
+    "vernacular": "Konkomba",
+    "script": "ROMAN",
+    "name": "Konkomba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KNO",
+    "locale": "kno",
+    "vernacular": "Kono",
+    "script": "ROMAN",
+    "name": "Kono",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KOC",
+    "locale": "ko_cn",
+    "vernacular": "조선어",
+    "script": "KOREAN",
+    "name": "Korean (China)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OS",
+    "locale": "kos",
+    "vernacular": "Kosraean",
+    "script": "ROMAN",
+    "name": "Kosraean",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KTI",
+    "locale": "eko",
+    "vernacular": "Koti",
+    "script": "ROMAN",
+    "name": "Koti",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KP",
+    "locale": "xpe",
+    "vernacular": "Kpelle",
+    "script": "ROMAN",
+    "name": "Kpelle",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KRI",
+    "locale": "kri",
+    "vernacular": "Krio",
+    "script": "ROMAN",
+    "name": "Krio",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KRY",
+    "locale": "tt_x_kry",
+    "vernacular": "керәшен татар",
+    "script": "CYRILLIC",
+    "name": "Kryashen",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KUA",
+    "locale": "ksd",
+    "vernacular": "Tinata Tuna",
+    "script": "ROMAN",
+    "name": "Kuanua",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KHN",
+    "locale": "sbs",
+    "vernacular": "Kuhane (Subiya)",
+    "script": "ROMAN",
+    "name": "Kuhane (Subiya)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KUI",
+    "locale": "uki",
+    "vernacular": "Kui",
+    "script": "ROMAN",
+    "name": "Kui",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KNM",
+    "locale": "kun",
+    "vernacular": "Kunama",
+    "script": "ROMAN",
+    "name": "Kunama",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KDA",
+    "locale": "kdn",
+    "vernacular": "Kunda",
+    "script": "ROMAN",
+    "name": "Kunda",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RD",
+    "locale": "kmr_x_rd",
+    "vernacular": "Kurdî (Kurmancî)",
+    "script": "ROMAN",
+    "name": "Kurdish Kurmanji",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RDU",
+    "locale": "kmr_x_rdu",
+    "vernacular": "Kurdî Kurmancî (Kavkazûs)",
+    "script": "ROMAN",
+    "name": "Kurdish Kurmanji (Caucasus)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RDC",
+    "locale": "kmr_cyrl",
+    "vernacular": "К′öрди Кöрманщи (Кирили)",
+    "script": "CYRILLIC",
+    "name": "Kurdish Kurmanji (Cyrillic)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RDA",
+    "locale": "ckb",
+    "vernacular": "کوردی سۆرانی",
+    "script": "ARABIC",
+    "name": "Kurdish Sorani",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "KUR",
+    "locale": "kuj",
+    "vernacular": "Igikuria",
+    "script": "ROMAN",
+    "name": "Kuria",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KRH",
+    "locale": "kru",
+    "vernacular": "Kurukh",
+    "script": "ROMAN",
+    "name": "Kurukh",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KUS",
+    "locale": "kus",
+    "vernacular": "Kusaal",
+    "script": "ROMAN",
+    "name": "Kusaal",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KCC",
+    "locale": "kfr",
+    "vernacular": "કચ્છી",
+    "script": "GUJARATI",
+    "name": "Kutchi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KVM",
+    "locale": "olu",
+    "vernacular": "Kuvale (Mucubal)",
+    "script": "ROMAN",
+    "name": "Kuvale (Mucubal)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KUY",
+    "locale": "kdt",
+    "vernacular": "Kuy",
+    "script": "THAI",
+    "name": "Kuy",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WG",
+    "locale": "kwn",
+    "vernacular": "Rukwangali",
+    "script": "ROMAN",
+    "name": "Kwangali",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KY",
+    "locale": "kj",
+    "vernacular": "Oshikwanyama",
+    "script": "ROMAN",
+    "name": "Kwanyama",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KW",
+    "locale": "kwf",
+    "vernacular": "Kwara'ae",
+    "script": "ROMAN",
+    "name": "Kwara'ae",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KWS",
+    "locale": "nmg",
+    "vernacular": "Kwasio",
+    "script": "ROMAN",
+    "name": "Kwasio",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NKN",
+    "locale": "nyy_x_nkn",
+    "vernacular": "Kyangonde",
+    "script": "ROMAN",
+    "name": "Kyangonde",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LAD",
+    "locale": "lld_x_lad",
+    "vernacular": "Ladin de Gherdëina",
+    "script": "ROMAN",
+    "name": "Ladin (Gardenese)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LAH",
+    "locale": "lhu",
+    "vernacular": "Laˇhuˍ hkawˇ",
+    "script": "ROMAN",
+    "name": "Lahu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LKT",
+    "locale": "lkt",
+    "vernacular": "Lakotiya",
+    "script": "ROMAN",
+    "name": "Lakota",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AB",
+    "locale": "lam",
+    "vernacular": "Lamba",
+    "script": "ROMAN",
+    "name": "Lamba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LMD",
+    "locale": "lmn",
+    "vernacular": "Lambadi",
+    "script": "ROMAN",
+    "name": "Lambadi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LMB",
+    "locale": "lai",
+    "vernacular": "Chilambya",
+    "script": "ROMAN",
+    "name": "Lambya",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LN",
+    "locale": "laj",
+    "vernacular": "lango",
+    "script": "ROMAN",
+    "name": "Lango",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LA",
+    "locale": "lo",
+    "vernacular": "ລາວ",
+    "script": "LAOTIAN",
+    "name": "Laotian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LR",
+    "locale": "ldi",
+    "vernacular": "Kilari",
+    "script": "ROMAN",
+    "name": "Lari",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LTG",
+    "locale": "ltg",
+    "vernacular": "Latgalīšu",
+    "script": "ROMAN",
+    "name": "Latgalian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LT",
+    "locale": "lv",
+    "vernacular": "latviešu",
+    "script": "ROMAN",
+    "name": "Latvian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LSL",
+    "locale": "lsl",
+    "vernacular": "latviešu zīmju valoda",
+    "script": "ROMAN",
+    "name": "Latvian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LNN",
+    "locale": "llx",
+    "vernacular": "Lauan",
+    "script": "ROMAN",
+    "name": "Lauan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LBS",
+    "locale": "sgn_lb",
+    "vernacular": "لغة الإشارات اللبنانية",
+    "script": "ARABIC",
+    "name": "Lebanese Sign Language",
+    "isSignLanguage": true,
+    "isRTL": true
+  },
+  {
+    "code": "LGA",
+    "locale": "lea",
+    "vernacular": "Lega",
+    "script": "ROMAN",
+    "name": "Lega",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LL",
+    "locale": "lln",
+    "vernacular": "Lele",
+    "script": "ROMAN",
+    "name": "Lele",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LNK",
+    "locale": "tnl",
+    "vernacular": "Lenakel",
+    "script": "ROMAN",
+    "name": "Lenakel",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LND",
+    "locale": "led",
+    "vernacular": "Baledha",
+    "script": "ROMAN",
+    "name": "Lendu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LJ",
+    "locale": "leh",
+    "vernacular": "Cilenje",
+    "script": "ROMAN",
+    "name": "Lenje",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LZ",
+    "locale": "lez",
+    "vernacular": "лезги",
+    "script": "CYRILLIC",
+    "name": "Lezgian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LHK",
+    "locale": "koo",
+    "vernacular": "Lhukonzo",
+    "script": "ROMAN",
+    "name": "Lhukonzo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ELI",
+    "locale": "lir",
+    "vernacular": "Liberian English",
+    "script": "ROMAN",
+    "name": "Liberian English",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LWC",
+    "locale": "lia",
+    "vernacular": "Limba (West-Central)",
+    "script": "ROMAN",
+    "name": "Limba (West-Central)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LBM",
+    "locale": "lmp",
+    "vernacular": "Limbum",
+    "script": "ROMAN",
+    "name": "Limbum",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LI",
+    "locale": "ln",
+    "vernacular": "Lingala",
+    "script": "ROMAN",
+    "name": "Lingala",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LIS",
+    "locale": "lis",
+    "vernacular": "ꓡꓲ-ꓢꓴ",
+    "script": "LISU",
+    "name": "Lisu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "L",
+    "locale": "lt",
+    "vernacular": "lietuvių",
+    "script": "ROMAN",
+    "name": "Lithuanian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LTS",
+    "locale": "lls",
+    "vernacular": "lietuvių gestų",
+    "script": "ROMAN",
+    "name": "Lithuanian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "LKA",
+    "locale": "yaz",
+    "vernacular": "Lokaa",
+    "script": "ROMAN",
+    "name": "Lokaa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LLO",
+    "locale": "llb",
+    "vernacular": "Ilolo",
+    "script": "ROMAN",
+    "name": "Lolo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OM",
+    "locale": "lom",
+    "vernacular": "Lɔɔma",
+    "script": "ROMAN",
+    "name": "Loma",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LOM",
+    "locale": "lol",
+    "vernacular": "Lɔmɔngɔ",
+    "script": "ROMAN",
+    "name": "Lomongo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LE",
+    "locale": "ngl",
+    "vernacular": "Elomwe",
+    "script": "ROMAN",
+    "name": "Lomwe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LGD",
+    "locale": "lnu",
+    "vernacular": "Longuda",
+    "script": "ROMAN",
+    "name": "Longuda",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LWX",
+    "locale": "pdt",
+    "vernacular": "Plautdietsch",
+    "script": "ROMAN",
+    "name": "Low German",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LC",
+    "locale": "lch",
+    "vernacular": "Luchazi",
+    "script": "ROMAN",
+    "name": "Luchazi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LU",
+    "locale": "lg",
+    "vernacular": "Luganda",
+    "script": "ROMAN",
+    "name": "Luganda",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LG",
+    "locale": "lgg",
+    "vernacular": "Lugbara",
+    "script": "ROMAN",
+    "name": "Lugbara",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LD",
+    "locale": "lun",
+    "vernacular": "Lunda",
+    "script": "ROMAN",
+    "name": "Lunda",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LO",
+    "locale": "luo",
+    "vernacular": "Dholuo",
+    "script": "ROMAN",
+    "name": "Luo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LV",
+    "locale": "lue",
+    "vernacular": "Luvale",
+    "script": "ROMAN",
+    "name": "Luvale",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LX",
+    "locale": "lb",
+    "vernacular": "Lëtzebuergesch",
+    "script": "ROMAN",
+    "name": "Luxembourgish",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MS",
+    "locale": "mas",
+    "vernacular": "Maasai",
+    "script": "ROMAN",
+    "name": "Maasai",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MC",
+    "locale": "mk",
+    "vernacular": "македонски",
+    "script": "CYRILLIC",
+    "name": "Macedonian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MAC",
+    "locale": "vmw",
+    "vernacular": "Emakhuwa",
+    "script": "ROMAN",
+    "name": "Macua",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MCT",
+    "locale": "fij_x_mct",
+    "vernacular": "Macuata",
+    "script": "ROMAN",
+    "name": "Macuata",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MCS",
+    "locale": "mbc",
+    "vernacular": "Makusi",
+    "script": "ROMAN",
+    "name": "Macushi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TTM",
+    "locale": "mzc",
+    "vernacular": "Tenin’ny Tanana Malagasy",
+    "script": "ROMAN",
+    "name": "Madagascar Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "MDI",
+    "locale": "mhi",
+    "vernacular": "Madi",
+    "script": "ROMAN",
+    "name": "Madi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MDR",
+    "locale": "mad",
+    "vernacular": "Madura",
+    "script": "ROMAN",
+    "name": "Madura",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MAF",
+    "locale": "maf",
+    "vernacular": "Mafa",
+    "script": "ROMAN",
+    "name": "Mafa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MU",
+    "locale": "mdh",
+    "vernacular": "Maguindanao",
+    "script": "ROMAN",
+    "name": "Maguindanao",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ORR",
+    "locale": "swb_x_orr",
+    "vernacular": "Shimaore (Alifuɓe)",
+    "script": "ROMAN",
+    "name": "Mahorian (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MHL",
+    "locale": "mai",
+    "vernacular": "मैथिली",
+    "script": "DEVANAGARI",
+    "name": "Maithili",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MKA",
+    "locale": "mcp",
+    "vernacular": "Makaa",
+    "script": "ROMAN",
+    "name": "Makaa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MKS",
+    "locale": "mkz_x_mks",
+    "vernacular": "Makasae",
+    "script": "ROMAN",
+    "name": "Makasae",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MHM",
+    "locale": "xmc",
+    "vernacular": "Makhuwa-Marrevone",
+    "script": "ROMAN",
+    "name": "Makhuwa-Marrevone",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MWM",
+    "locale": "mgh",
+    "vernacular": "Imakhuwa Imeetto",
+    "script": "ROMAN",
+    "name": "Makhuwa-Meetto",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MKM",
+    "locale": "mhm",
+    "vernacular": "Makhuwa-Moniga",
+    "script": "ROMAN",
+    "name": "Makhuwa-Moniga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MHS",
+    "locale": "vmk",
+    "vernacular": "Makhuwa-Shirima",
+    "script": "ROMAN",
+    "name": "Makhuwa-Shirima",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MKD",
+    "locale": "kde",
+    "vernacular": "Shimakonde",
+    "script": "ROMAN",
+    "name": "Makonde",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MG",
+    "locale": "mg",
+    "vernacular": "Malagasy",
+    "script": "ROMAN",
+    "name": "Malagasy",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MSL",
+    "locale": "sgn_mw",
+    "vernacular": "Chinenero Chamanja cha ku Malawi",
+    "script": "ROMAN",
+    "name": "Malawi Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "ML",
+    "locale": "ms",
+    "vernacular": "Melayu",
+    "script": "ROMAN",
+    "name": "Malay",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MPN",
+    "locale": "pmy",
+    "vernacular": "Malay (Papuan)",
+    "script": "ROMAN",
+    "name": "Malay (Papuan)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MY",
+    "locale": "ml",
+    "vernacular": "മലയാളം",
+    "script": "MALAYALAM",
+    "name": "Malayalam",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MLY",
+    "locale": "mbp",
+    "vernacular": "wiwa dumuna",
+    "script": "ROMAN",
+    "name": "Malayo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BIM",
+    "locale": "xml",
+    "vernacular": "Bahasa Isyarat Malaysia",
+    "script": "ROMAN",
+    "name": "Malaysian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "MT",
+    "locale": "mt",
+    "vernacular": "Malti",
+    "script": "ROMAN",
+    "name": "Maltese",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MLS",
+    "locale": "mdl",
+    "vernacular": "Lingwa tas-Sinjali Maltija",
+    "script": "ROMAN",
+    "name": "Maltese Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "MZ",
+    "locale": "mam",
+    "vernacular": "mam",
+    "script": "ROMAN",
+    "name": "Mam",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AMA",
+    "locale": "mqj",
+    "vernacular": "Mamasa",
+    "script": "ROMAN",
+    "name": "Mamasa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MME",
+    "locale": "mgm_x_mme",
+    "vernacular": "Mambae (Ermera)",
+    "script": "ROMAN",
+    "name": "Mambae (Ermera)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MWL",
+    "locale": "mgr",
+    "vernacular": "Cimambwe-Lungu",
+    "script": "ROMAN",
+    "name": "Mambwe-Lungu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MNM",
+    "locale": "xmm",
+    "vernacular": "Manado",
+    "script": "ROMAN",
+    "name": "Manado Malay",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MDL",
+    "locale": "mjl",
+    "vernacular": "Mandeali",
+    "script": "ROMAN",
+    "name": "Mandeali",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MNK",
+    "locale": "mnk",
+    "vernacular": "Mandinka",
+    "script": "ROMAN",
+    "name": "Mandinka",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MNJ",
+    "locale": "mzv",
+    "vernacular": "Mandja",
+    "script": "ROMAN",
+    "name": "Mandja",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MJK",
+    "locale": "mfv",
+    "vernacular": "Manjaku",
+    "script": "ROMAN",
+    "name": "Mandjak",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MGR",
+    "locale": "mrv",
+    "vernacular": "Mangareva",
+    "script": "ROMAN",
+    "name": "Mangareva",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MKE",
+    "locale": "emk",
+    "vernacular": "Mandingo",
+    "script": "ROMAN",
+    "name": "Maninkakan (Eastern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MI",
+    "locale": "mni",
+    "vernacular": "মৈতৈলোন্",
+    "script": "BENGALI",
+    "name": "Manipuri",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MIR",
+    "locale": "mni_latn",
+    "vernacular": "Manipuri (Roman)",
+    "script": "ROMAN",
+    "name": "Manipuri (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MNO",
+    "locale": "mev",
+    "vernacular": "Maa",
+    "script": "ROMAN",
+    "name": "Mano",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MNI",
+    "locale": "mns",
+    "vernacular": "маньси",
+    "script": "CYRILLIC",
+    "name": "Mansi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MYW",
+    "locale": "mny",
+    "vernacular": "Emanyawa",
+    "script": "ROMAN",
+    "name": "Manyawa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MA",
+    "locale": "mi",
+    "vernacular": "Te Reo Māori",
+    "script": "ROMAN",
+    "name": "Maori",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MPD",
+    "locale": "arn",
+    "vernacular": "mapudungun",
+    "script": "ROMAN",
+    "name": "Mapudungun",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MQR",
+    "locale": "mch",
+    "vernacular": "Ye’kuana",
+    "script": "ROMAN",
+    "name": "Maquiritari",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OL",
+    "locale": "rag",
+    "vernacular": "Luragooli",
+    "script": "ROMAN",
+    "name": "Maragoli",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MR",
+    "locale": "mr",
+    "vernacular": "मराठी",
+    "script": "DEVANAGARI",
+    "name": "Marathi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MAR",
+    "locale": "mhr",
+    "vernacular": "марий",
+    "script": "CYRILLIC",
+    "name": "Mari",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MRH",
+    "locale": "mrj",
+    "vernacular": "кырык мары",
+    "script": "CYRILLIC",
+    "name": "Mari (Hill)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MQN",
+    "locale": "mrq",
+    "vernacular": "Marquisien (Nuku Hiva)",
+    "script": "ROMAN",
+    "name": "Marquesian (Nuku Hiva)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MH",
+    "locale": "mh",
+    "vernacular": "Kajin M̦ajel̦",
+    "script": "ROMAN",
+    "name": "Marshallese",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MTC",
+    "locale": "gcf_x_mtc",
+    "vernacular": "Kréyol Matinik",
+    "script": "ROMAN",
+    "name": "Martiniquan Creole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MRW",
+    "locale": "rwr",
+    "vernacular": "Marwari",
+    "script": "ROMAN",
+    "name": "Marwari",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MSH",
+    "locale": "shr",
+    "vernacular": "Mashi",
+    "script": "ROMAN",
+    "name": "Mashi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MTN",
+    "locale": "mgv",
+    "vernacular": "Kimatengo",
+    "script": "ROMAN",
+    "name": "Matengo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MSS",
+    "locale": "mcf",
+    "vernacular": "Matses",
+    "script": "ROMAN",
+    "name": "Matses",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CE",
+    "locale": "mfe",
+    "vernacular": "Kreol Morisien",
+    "script": "ROMAN",
+    "name": "Mauritian Creole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MTS",
+    "locale": "lsy",
+    "vernacular": "Mauritian Sign Language",
+    "script": "ROMAN",
+    "name": "Mauritian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "MAY",
+    "locale": "yua",
+    "vernacular": "maaya",
+    "script": "ROMAN",
+    "name": "Maya",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MAP",
+    "locale": "mop",
+    "vernacular": "T'an",
+    "script": "ROMAN",
+    "name": "Maya (Mopán)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MYG",
+    "locale": "yan",
+    "vernacular": "mayangna",
+    "script": "ROMAN",
+    "name": "Mayangna",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MYO",
+    "locale": "mfy",
+    "vernacular": "yoremnok'ki",
+    "script": "ROMAN",
+    "name": "Mayo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MZH",
+    "locale": "maz",
+    "vernacular": "jñatrjo",
+    "script": "ROMAN",
+    "name": "Mazahua",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MAZ",
+    "locale": "mau",
+    "vernacular": "énná",
+    "script": "ROMAN",
+    "name": "Mazatec (Huautla)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MBL",
+    "locale": "mdp",
+    "vernacular": "Gimbala",
+    "script": "ROMAN",
+    "name": "Mbala",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MBN",
+    "locale": "mxg",
+    "vernacular": "Mbangala",
+    "script": "ROMAN",
+    "name": "Mbangala",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MBO",
+    "locale": "mbo",
+    "vernacular": "Mbo",
+    "script": "ROMAN",
+    "name": "Mbo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MBK",
+    "locale": "mhw",
+    "vernacular": "Thimbukushu",
+    "script": "ROMAN",
+    "name": "Mbukushu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MMU",
+    "locale": "mdd",
+    "vernacular": "Mbum",
+    "script": "ROMAN",
+    "name": "Mbum",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MBD",
+    "locale": "mck",
+    "vernacular": "Mbunda",
+    "script": "ROMAN",
+    "name": "Mbunda",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MDH",
+    "locale": "nan_x_mdh",
+    "vernacular": "Hokkien Medan",
+    "script": "ROMAN",
+    "name": "Medan Hokkien",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DU",
+    "locale": "byv",
+    "vernacular": "Bangangté",
+    "script": "ROMAN",
+    "name": "Medumba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MNS",
+    "locale": "sgn_pg",
+    "vernacular": "Melanesian Sign Language",
+    "script": "ROMAN",
+    "name": "Melanesian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "ME",
+    "locale": "men",
+    "vernacular": "Mɛnde",
+    "script": "ROMAN",
+    "name": "Mende",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MGK",
+    "locale": "xmg",
+    "vernacular": "Mengaka",
+    "script": "ROMAN",
+    "name": "Mengaka",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MWI",
+    "locale": "mwv",
+    "vernacular": "Mentawai",
+    "script": "ROMAN",
+    "name": "Mentawai",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "UU",
+    "locale": "mer",
+    "vernacular": "Kĩmĩĩrũ",
+    "script": "ROMAN",
+    "name": "Meru",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MTA",
+    "locale": "mgo",
+    "vernacular": "Meta'",
+    "script": "ROMAN",
+    "name": "Meta'",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MWR",
+    "locale": "mtr",
+    "vernacular": "Mewari",
+    "script": "ROMAN",
+    "name": "Mewari",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CHN",
+    "locale": "nan_x_chn",
+    "vernacular": "闽南语（泉州）",
+    "script": "CHINESE",
+    "name": "Min Nan (Quanzhou)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CHW",
+    "locale": "nan_x_chw",
+    "vernacular": "閩南語（台灣）",
+    "script": "CHINESE",
+    "name": "Min Nan (Taiwan)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MGL",
+    "locale": "xmf",
+    "vernacular": "მარგალური",
+    "script": "GEORGIAN",
+    "name": "Mingrelian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MIS",
+    "locale": "miq",
+    "vernacular": "miskitu",
+    "script": "ROMAN",
+    "name": "Miskito",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MX",
+    "locale": "mco",
+    "vernacular": "ayuk",
+    "script": "ROMAN",
+    "name": "Mixe (North Central)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MXC",
+    "locale": "mio",
+    "vernacular": "saʼan xiñi saví",
+    "script": "ROMAN",
+    "name": "Mixtec (Costa)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MXG",
+    "locale": "mxv",
+    "vernacular": "tu’un sâví",
+    "script": "ROMAN",
+    "name": "Mixtec (Guerrero)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MXO",
+    "locale": "jmx",
+    "vernacular": "Tu̱ʼun ndaʼví",
+    "script": "ROMAN",
+    "name": "Mixtec (Huajuapan)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MXN",
+    "locale": "xtd",
+    "vernacular": "ñutnuu",
+    "script": "ROMAN",
+    "name": "Mixtec (Tilantongo)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MXT",
+    "locale": "meh",
+    "vernacular": "saʼan savi",
+    "script": "ROMAN",
+    "name": "Mixtec (Tlaxiaco)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LS",
+    "locale": "lus",
+    "vernacular": "Mizo",
+    "script": "ROMAN",
+    "name": "Mizo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MKQ",
+    "locale": "mic",
+    "vernacular": "Mi'kmaw",
+    "script": "ROMAN",
+    "name": "Mi’kmaq",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MNC",
+    "locale": "cmo",
+    "vernacular": "Bunong",
+    "script": "ROMAN",
+    "name": "Mnong (Central)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MBA",
+    "locale": "mfq",
+    "vernacular": "Muaba",
+    "script": "ROMAN",
+    "name": "Moba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MHK",
+    "locale": "moh",
+    "vernacular": "Kanienʼkéha",
+    "script": "ROMAN",
+    "name": "Mohawk",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MOK",
+    "locale": "mdf",
+    "vernacular": "мокшень",
+    "script": "CYRILLIC",
+    "name": "Moksha",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KHA",
+    "locale": "mn",
+    "vernacular": "монгол",
+    "script": "CYRILLIC",
+    "name": "Mongolian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KHC",
+    "locale": "mvf",
+    "vernacular": "Mongolian (Traditional)",
+    "script": "MONGOLIAN",
+    "name": "Mongolian (Traditional)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MSR",
+    "locale": "msr",
+    "vernacular": "монгол дохионы хэл",
+    "script": "CYRILLIC",
+    "name": "Mongolian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "MNT",
+    "locale": "cnr",
+    "vernacular": "crnogorski",
+    "script": "ROMAN",
+    "name": "Montenegrin",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MM",
+    "locale": "mos",
+    "vernacular": "Moore",
+    "script": "ROMAN",
+    "name": "Moore",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MTU",
+    "locale": "meu",
+    "vernacular": "Motu",
+    "script": "ROMAN",
+    "name": "Motu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OU",
+    "locale": "mua",
+    "vernacular": "Moundang",
+    "script": "ROMAN",
+    "name": "Moundang",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MOU",
+    "locale": "mse",
+    "vernacular": "Moussey",
+    "script": "ROMAN",
+    "name": "Moussey",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SLM",
+    "locale": "mzy",
+    "vernacular": "Língua de Sinais Moçambicana",
+    "script": "ROMAN",
+    "name": "Mozambican Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "MNR",
+    "locale": "unr",
+    "vernacular": "Mundari",
+    "script": "ROMAN",
+    "name": "Mundari",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BU",
+    "locale": "my",
+    "vernacular": "မြန်မာ",
+    "script": "MYANMAR",
+    "name": "Myanmar",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BUS",
+    "locale": "sgn_mm",
+    "vernacular": "မြန်မာ လက်သင်္ကေတပြဘာသာစကား",
+    "script": "MYANMAR",
+    "name": "Myanmar Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "NDI",
+    "locale": "fij_x_ndi",
+    "vernacular": "Nadi",
+    "script": "ROMAN",
+    "name": "Nadi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NDR",
+    "locale": "wyy_x_ndr",
+    "vernacular": "Nadroga",
+    "script": "ROMAN",
+    "name": "Nadroga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NGG",
+    "locale": "njm",
+    "vernacular": "Naga (Angami)",
+    "script": "ROMAN",
+    "name": "Naga (Angami)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NLM",
+    "locale": "njn",
+    "vernacular": "Naga (Liangmai)",
+    "script": "ROMAN",
+    "name": "Naga (Liangmai)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NGR",
+    "locale": "nbu",
+    "vernacular": "Naga (Rongmei)",
+    "script": "ROMAN",
+    "name": "Naga (Rongmei)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NGD",
+    "locale": "nag",
+    "vernacular": "Nagamese",
+    "script": "ROMAN",
+    "name": "Nagamese",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NHC",
+    "locale": "ncx",
+    "vernacular": "náhuatl del centro",
+    "script": "ROMAN",
+    "name": "Nahuatl (Central)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NHG",
+    "locale": "ngu",
+    "vernacular": "náhuatl de guerrero",
+    "script": "ROMAN",
+    "name": "Nahuatl (Guerrero)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NHH",
+    "locale": "nch",
+    "vernacular": "náhuatl de la huasteca",
+    "script": "ROMAN",
+    "name": "Nahuatl (Huasteca)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NHT",
+    "locale": "ncj",
+    "vernacular": "náhuatl del norte de Puebla",
+    "script": "ROMAN",
+    "name": "Nahuatl (Northern Puebla)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NHV",
+    "locale": "nhk",
+    "vernacular": "náhuatl de Veracruz",
+    "script": "ROMAN",
+    "name": "Nahuatl (Veracruz)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NA",
+    "locale": "naq_x_na",
+    "vernacular": "ǀApakhoen gowab",
+    "script": "ROMAN",
+    "name": "Nama",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NMK",
+    "locale": "nmk",
+    "vernacular": "Namakura",
+    "script": "ROMAN",
+    "name": "Namakura",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NB",
+    "locale": "nmq",
+    "vernacular": "Nambya",
+    "script": "ROMAN",
+    "name": "Nambya",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SLN",
+    "locale": "nbs",
+    "vernacular": "Namibian Sign Language",
+    "script": "ROMAN",
+    "name": "Namibian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "NNR",
+    "locale": "bwb",
+    "vernacular": "Namosi-Naitasiri-Serua",
+    "script": "ROMAN",
+    "name": "Namosi-Naitasiri-Serua",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NCW",
+    "locale": "ncb",
+    "vernacular": "Nancowry",
+    "script": "ROMAN",
+    "name": "Nancowry",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NV",
+    "locale": "nv",
+    "vernacular": "Diné Bizaad",
+    "script": "ROMAN",
+    "name": "Navajo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NDL",
+    "locale": "ndh",
+    "vernacular": "Ichindali",
+    "script": "ROMAN",
+    "name": "Ndali",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NDA",
+    "locale": "ndc",
+    "vernacular": "Cindau",
+    "script": "ROMAN",
+    "name": "Ndau",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NDW",
+    "locale": "ndc_x_ndw",
+    "vernacular": "Ndau (Western)",
+    "script": "ROMAN",
+    "name": "Ndau (Western)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NBL",
+    "locale": "nr",
+    "vernacular": "IsiNdebele",
+    "script": "ROMAN",
+    "name": "Ndebele",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NBZ",
+    "locale": "nd",
+    "vernacular": "Ndebele (Zimbabwe)",
+    "script": "ROMAN",
+    "name": "Ndebele (Zimbabwe)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OD",
+    "locale": "ng",
+    "vernacular": "Oshindonga",
+    "script": "ROMAN",
+    "name": "Ndonga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NNT",
+    "locale": "yrk",
+    "vernacular": "ненэцяʼ",
+    "script": "CYRILLIC",
+    "name": "Nenets",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RE",
+    "locale": "nen",
+    "vernacular": "Nengone",
+    "script": "ROMAN",
+    "name": "Nengone",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NP",
+    "locale": "ne",
+    "vernacular": "नेपाली",
+    "script": "DEVANAGARI",
+    "name": "Nepali",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NSL",
+    "locale": "nsp",
+    "vernacular": "नेपाली साङ्केतिक भाषा",
+    "script": "DEVANAGARI",
+    "name": "Nepali Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "NW",
+    "locale": "new",
+    "vernacular": "नेवारी",
+    "script": "DEVANAGARI",
+    "name": "Newari",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NGB",
+    "locale": "gym",
+    "vernacular": "ngäbere",
+    "script": "ROMAN",
+    "name": "Ngabere",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NG",
+    "locale": "sba",
+    "vernacular": "Ngambay",
+    "script": "ROMAN",
+    "name": "Ngambaye",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NGL",
+    "locale": "nba",
+    "vernacular": "Ngangela",
+    "script": "ROMAN",
+    "name": "Ngangela",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NGK",
+    "locale": "nga",
+    "vernacular": "Ngbaka",
+    "script": "ROMAN",
+    "name": "Ngbaka",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NGN",
+    "locale": "ngb",
+    "vernacular": "Ngbandi (ya Nɔrdi)",
+    "script": "ROMAN",
+    "name": "Ngbandi (Northern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NMB",
+    "locale": "nnh",
+    "vernacular": "Ngiemboon",
+    "script": "ROMAN",
+    "name": "Ngiemboon",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NGM",
+    "locale": "pls",
+    "vernacular": "ngigua de San Marcos Tlacoyalco",
+    "script": "ROMAN",
+    "name": "Ngigua (San Marcos Tlacoyalco)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NML",
+    "locale": "nla",
+    "vernacular": "Babadjou",
+    "script": "ROMAN",
+    "name": "Ngombale",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NGU",
+    "locale": "yrl",
+    "vernacular": "Nheengatu",
+    "script": "ROMAN",
+    "name": "Nhengatu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NI",
+    "locale": "nia",
+    "vernacular": "Nias",
+    "script": "ROMAN",
+    "name": "Nias",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NC",
+    "locale": "caq",
+    "vernacular": "Nicobarese",
+    "script": "ROMAN",
+    "name": "Nicobarese",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NGP",
+    "locale": "pcm",
+    "vernacular": "Nigerian Pidgin",
+    "script": "ROMAN",
+    "name": "Nigerian Pidgin",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NNS",
+    "locale": "nsi",
+    "vernacular": "Nigerian Sign Language",
+    "script": "ROMAN",
+    "name": "Nigerian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "NN",
+    "locale": "niu",
+    "vernacular": "Faka-Niue",
+    "script": "ROMAN",
+    "name": "Niuean",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NVC",
+    "locale": "cag",
+    "vernacular": "nivaĉle",
+    "script": "ROMAN",
+    "name": "Nivaclé",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NJB",
+    "locale": "nzb",
+    "vernacular": "Njebi",
+    "script": "ROMAN",
+    "name": "Njebi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NKY",
+    "locale": "nka",
+    "vernacular": "Nkoya",
+    "script": "ROMAN",
+    "name": "Nkoya",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NOR",
+    "locale": "ojb_x_nor",
+    "vernacular": "Anishinaabemowin",
+    "script": "ROMAN",
+    "name": "Northern Ojibwe (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NOS",
+    "locale": "ojb_x_nos",
+    "vernacular": "ᐊᓂᔑᓈᐯᒧᐎᓐ",
+    "script": "CANADIAN_SY",
+    "name": "Northern Ojibwe (Syllabics)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "N",
+    "locale": "no",
+    "vernacular": "Norsk",
+    "script": "ROMAN",
+    "name": "Norwegian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NDF",
+    "locale": "nsl",
+    "vernacular": "Norsk tegnspråk",
+    "script": "ROMAN",
+    "name": "Norwegian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "NSM",
+    "locale": "nse_mz",
+    "vernacular": "Chinsenga (Mozambique)",
+    "script": "ROMAN",
+    "name": "Nsenga (Mozambique)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NEN",
+    "locale": "nse",
+    "vernacular": "Cinsenga",
+    "script": "ROMAN",
+    "name": "Nsenga (Zambia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "UE",
+    "locale": "nus",
+    "vernacular": "Thok Nath",
+    "script": "ROMAN",
+    "name": "Nuer",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NKM",
+    "locale": "nuq",
+    "vernacular": "Nukumanu",
+    "script": "ROMAN",
+    "name": "Nukumanu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KWN",
+    "locale": "kdk",
+    "vernacular": "Kwényï",
+    "script": "ROMAN",
+    "name": "Numèè (Kwenyii)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YM",
+    "locale": "nym",
+    "vernacular": "Nyamwezi",
+    "script": "ROMAN",
+    "name": "Nyamwezi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NK",
+    "locale": "nyk",
+    "vernacular": "Nyaneka",
+    "script": "ROMAN",
+    "name": "Nyaneka",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NYL",
+    "locale": "yly",
+    "vernacular": "Nyelâyu",
+    "script": "ROMAN",
+    "name": "Nyelâyu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NY",
+    "locale": "nih",
+    "vernacular": "Nyiha",
+    "script": "ROMAN",
+    "name": "Nyiha",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NYU",
+    "locale": "nyu",
+    "vernacular": "Cinyungwe",
+    "script": "ROMAN",
+    "name": "Nyungwe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NZ",
+    "locale": "nzi",
+    "vernacular": "Nzema",
+    "script": "ROMAN",
+    "name": "Nzema",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OBL",
+    "locale": "ann",
+    "vernacular": "Obolo",
+    "script": "ROMAN",
+    "name": "Obolo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ODW",
+    "locale": "otw",
+    "vernacular": "Nishnaabemwin",
+    "script": "ROMAN",
+    "name": "Odawa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OI",
+    "locale": "or",
+    "vernacular": "ଓଡ଼ିଆ",
+    "script": "ORIYA",
+    "name": "Odia",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OKP",
+    "locale": "oke",
+    "vernacular": "Okpe",
+    "script": "ROMAN",
+    "name": "Okpe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LB",
+    "locale": "nyd",
+    "vernacular": "Olunyole",
+    "script": "ROMAN",
+    "name": "Olunyole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OMB",
+    "locale": "mbm",
+    "vernacular": "Ombamba",
+    "script": "ROMAN",
+    "name": "Ombamba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ORK",
+    "locale": "okv",
+    "vernacular": "Orokaiva",
+    "script": "ROMAN",
+    "name": "Orokaiva",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OA",
+    "locale": "om",
+    "vernacular": "Afaan Oromoo",
+    "script": "ROMAN",
+    "name": "Oromo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OSS",
+    "locale": "os",
+    "vernacular": "ирон",
+    "script": "CYRILLIC",
+    "name": "Ossetian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OSC",
+    "locale": "os_x_osc",
+    "vernacular": "Ирон (чысайнаг)",
+    "script": "CYRILLIC",
+    "name": "Ossetian (Chsan)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OSK",
+    "locale": "os_x_osk",
+    "vernacular": "Ирон (къуыдайраг)",
+    "script": "CYRILLIC",
+    "name": "Ossetian (Kudar)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OT",
+    "locale": "tll",
+    "vernacular": "Ɔtɛtɛla",
+    "script": "ROMAN",
+    "name": "Otetela",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OTE",
+    "locale": "otm",
+    "vernacular": "ñuhü",
+    "script": "ROMAN",
+    "name": "Otomi (Eastern Highland)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OTM",
+    "locale": "ote",
+    "vernacular": "Ñañu",
+    "script": "ROMAN",
+    "name": "Otomi (Mezquital Valley)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OTS",
+    "locale": "ots",
+    "vernacular": "ñätho",
+    "script": "ROMAN",
+    "name": "Otomi (State of Mexico)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PPG",
+    "locale": "ood",
+    "vernacular": "O’odham",
+    "script": "ROMAN",
+    "name": "O’odham (Tohono)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PAO",
+    "locale": "blk",
+    "vernacular": "Pa'o",
+    "script": "MYANMAR",
+    "name": "Pa'o",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PMA",
+    "locale": "pma",
+    "vernacular": "Paama",
+    "script": "ROMAN",
+    "name": "Paama",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PIC",
+    "locale": "pri",
+    "vernacular": "Paicî",
+    "script": "ROMAN",
+    "name": "Paicî",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PWN",
+    "locale": "pwn",
+    "vernacular": "Payuan",
+    "script": "ROMAN",
+    "name": "Paiwan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PU",
+    "locale": "pau",
+    "vernacular": "Palauan",
+    "script": "ROMAN",
+    "name": "Palauan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PLK",
+    "locale": "plu",
+    "vernacular": "Palikur",
+    "script": "ROMAN",
+    "name": "Palikúr",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PMO",
+    "locale": "pmf",
+    "vernacular": "Pamona",
+    "script": "ROMAN",
+    "name": "Pamona",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PN",
+    "locale": "pag",
+    "vernacular": "Pangasinan",
+    "script": "ROMAN",
+    "name": "Pangasinan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PPL",
+    "locale": "pbo",
+    "vernacular": "Oium",
+    "script": "ROMAN",
+    "name": "Papel",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PAA",
+    "locale": "pap_x_paa",
+    "vernacular": "Papiamento (Aruba)",
+    "script": "ROMAN",
+    "name": "Papiamento (Aruba)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PA",
+    "locale": "pap",
+    "vernacular": "Papiamentu (Kòrsou)",
+    "script": "ROMAN",
+    "name": "Papiamento (Curaçao)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PH",
+    "locale": "ps",
+    "vernacular": "پښتو",
+    "script": "ARABIC",
+    "name": "Pashto",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "PHN",
+    "locale": "arn_x_phn",
+    "vernacular": "chedungun (pewenche)",
+    "script": "ROMAN",
+    "name": "Pehuenche",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PMN",
+    "locale": "aoc",
+    "vernacular": "pemon pe",
+    "script": "ROMAN",
+    "name": "Pemon",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "XPA",
+    "locale": "pdc",
+    "vernacular": "Pennsylvania Dutch (Deitsh)",
+    "script": "ROMAN",
+    "name": "Pennsylvania German",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PR",
+    "locale": "fa",
+    "vernacular": "فارسی",
+    "script": "ARABIC",
+    "name": "Persian",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "PHM",
+    "locale": "phm",
+    "vernacular": "Chiphimbi",
+    "script": "ROMAN",
+    "name": "Phimbi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SIH",
+    "locale": "pht",
+    "vernacular": "ภูไท",
+    "script": "THAI",
+    "name": "Phu Thai",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PRA",
+    "locale": "pid",
+    "vernacular": "huo̧ttö̧ja̧",
+    "script": "ROMAN",
+    "name": "Piaroa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PCM",
+    "locale": "wes",
+    "vernacular": "Pidgin for Cameroon",
+    "script": "ROMAN",
+    "name": "Pidgin (Cameroon)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PGW",
+    "locale": "wes_x_pgw",
+    "vernacular": "Pidgin (West Africa)",
+    "script": "ROMAN",
+    "name": "Pidgin (West Africa)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PLG",
+    "locale": "plg",
+    "vernacular": "pilagá",
+    "script": "ROMAN",
+    "name": "Pilagá",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PTJ",
+    "locale": "pjt",
+    "vernacular": "Pitjantjatjara",
+    "script": "ROMAN",
+    "name": "Pitjantjatjara",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PP",
+    "locale": "pon",
+    "vernacular": "Lokaiahn Pohnpei",
+    "script": "ROMAN",
+    "name": "Pohnpeian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "P",
+    "locale": "pl",
+    "vernacular": "polski",
+    "script": "ROMAN",
+    "name": "Polish",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PDF",
+    "locale": "pso",
+    "vernacular": "polski język migowy",
+    "script": "ROMAN",
+    "name": "Polish Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "PMR",
+    "locale": "nds",
+    "vernacular": "Pomerisch",
+    "script": "ROMAN",
+    "name": "Pomeranian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PPU",
+    "locale": "poi",
+    "vernacular": "popoluca de la Sierra",
+    "script": "ROMAN",
+    "name": "Popoluca (Highland)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "JC",
+    "locale": "jac_x_jc",
+    "vernacular": "poptí",
+    "script": "ROMAN",
+    "name": "Popti'",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PQM",
+    "locale": "poh",
+    "vernacular": "poqomchi'",
+    "script": "ROMAN",
+    "name": "Poqomchi'",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TNG",
+    "locale": "pt_ao",
+    "vernacular": "Português (Angola)",
+    "script": "ROMAN",
+    "name": "Portuguese (Angola)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "T",
+    "locale": "pt",
+    "vernacular": "Português (Brasil)",
+    "script": "ROMAN",
+    "name": "Portuguese (Brazil)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LSB",
+    "locale": "bzs",
+    "vernacular": "Língua brasileira de sinais (Libras)",
+    "script": "ROMAN",
+    "name": "Brazilian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "TMM",
+    "locale": "pt_mz",
+    "vernacular": "Português (Moçambique)",
+    "script": "ROMAN",
+    "name": "Portuguese (Mozambique)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PLR",
+    "locale": "fuf",
+    "vernacular": "Fula",
+    "script": "ROMAN",
+    "name": "Pular",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PJ",
+    "locale": "pa",
+    "vernacular": "ਪੰਜਾਬੀ",
+    "script": "GURMUKHI",
+    "name": "Punjabi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PJN",
+    "locale": "pnb",
+    "vernacular": "پنجابی (شاہ مُکھی)",
+    "script": "URDU",
+    "name": "Punjabi (Shahmukhi)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "PUN",
+    "locale": "puu",
+    "vernacular": "Punu",
+    "script": "ROMAN",
+    "name": "Punu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PYM",
+    "locale": "pyu",
+    "vernacular": "Pinuyumayan",
+    "script": "ROMAN",
+    "name": "Puyuma",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "PAZ",
+    "locale": "pbb",
+    "vernacular": "nasa yuwe",
+    "script": "ROMAN",
+    "name": "Páez",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QNJ",
+    "locale": "kjb",
+    "vernacular": "q'anjob'al",
+    "script": "ROMAN",
+    "name": "Q'anjob'al",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QUN",
+    "locale": "que",
+    "vernacular": "Quechua (Ancash)",
+    "script": "ROMAN",
+    "name": "Quechua (Ancash)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QUA",
+    "locale": "quy",
+    "vernacular": "Quechua (Ayacucho)",
+    "script": "ROMAN",
+    "name": "Quechua (Ayacucho)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QUB",
+    "locale": "qu",
+    "vernacular": "Quechua (Bolivia)",
+    "script": "ROMAN",
+    "name": "Quechua (Bolivia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QU",
+    "locale": "quz",
+    "vernacular": "quechua (Cusco)",
+    "script": "ROMAN",
+    "name": "Quechua (Cuzco)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QUL",
+    "locale": "qub",
+    "vernacular": "Quechua de Huánuco (Huallaga)",
+    "script": "ROMAN",
+    "name": "Quechua (Huallaga Huánuco)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QUH",
+    "locale": "qvw",
+    "vernacular": "quechua wanca",
+    "script": "ROMAN",
+    "name": "Quechua (Huaylla Wanca)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QUM",
+    "locale": "quf",
+    "vernacular": "quechua (lambayeque)",
+    "script": "ROMAN",
+    "name": "Quechua (Lambayeque)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QC",
+    "locale": "quc",
+    "vernacular": "quiché",
+    "script": "ROMAN",
+    "name": "Quiche",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QCC",
+    "locale": "qxr",
+    "vernacular": "quichua (cañar)",
+    "script": "ROMAN",
+    "name": "Quichua (Cañar)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QIB",
+    "locale": "qu_x_qib",
+    "vernacular": "quichua (chibuleo)",
+    "script": "ROMAN",
+    "name": "Quichua (Chibuleo)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QIC",
+    "locale": "qug",
+    "vernacular": "quichua (chimborazo)",
+    "script": "ROMAN",
+    "name": "Quichua (Chimborazo)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QIX",
+    "locale": "qug_x_qix",
+    "vernacular": "quichua (cotopaxi)",
+    "script": "ROMAN",
+    "name": "Quichua (Cotopaxi)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QII",
+    "locale": "qvi",
+    "vernacular": "quichua (imbabura)",
+    "script": "ROMAN",
+    "name": "Quichua (Imbabura)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QIP",
+    "locale": "qvz",
+    "vernacular": "quichua (pastaza)",
+    "script": "ROMAN",
+    "name": "Quichua (Pastaza)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QCS",
+    "locale": "qu_x_qxl",
+    "vernacular": "quichua (salasaca)",
+    "script": "ROMAN",
+    "name": "Quichua (Salasaca)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QIS",
+    "locale": "qus",
+    "vernacular": "quichua (Santiago del Estero)",
+    "script": "ROMAN",
+    "name": "Quichua (Santiago del Estero)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "QIT",
+    "locale": "quw",
+    "vernacular": "quichua (tena)",
+    "script": "ROMAN",
+    "name": "Quichua (Tena)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "FNR",
+    "locale": "fij_x_fnr",
+    "vernacular": "Ra",
+    "script": "ROMAN",
+    "name": "Ra",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RPN",
+    "locale": "rap",
+    "vernacular": "rapa nui",
+    "script": "ROMAN",
+    "name": "Rapa Nui",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RA",
+    "locale": "rar",
+    "vernacular": "Reo Rarotonga",
+    "script": "ROMAN",
+    "name": "Rarotongan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "M",
+    "locale": "ro",
+    "vernacular": "Română",
+    "script": "ROMAN",
+    "name": "Romanian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RNN",
+    "locale": "ro_x_rnn",
+    "vernacular": "rumunski (vlaški)",
+    "script": "ROMAN",
+    "name": "Romanian (Vlach)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RNK",
+    "locale": "ro_x_rnk",
+    "vernacular": "rumunski (vlaški, Bačka)",
+    "script": "ROMAN",
+    "name": "Romanian (Vlach, Bačka)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LMG",
+    "locale": "rms",
+    "vernacular": "Limba semnelor române",
+    "script": "ROMAN",
+    "name": "Romanian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "RH",
+    "locale": "rm_x_rh",
+    "vernacular": "Rumantsch (Ladin)",
+    "script": "ROMAN",
+    "name": "Romansh (Ladin)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RHS",
+    "locale": "rm_x_rhs",
+    "vernacular": "romontsch (sursilvan)",
+    "script": "ROMAN",
+    "name": "Romansh (Sursilvan)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RML",
+    "locale": "rmy_al",
+    "vernacular": "rome (shqipëri)",
+    "script": "ROMAN",
+    "name": "Romany (Albania)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMA",
+    "locale": "rmy_ar",
+    "vernacular": "Romanes Kalderash",
+    "script": "ROMAN",
+    "name": "Romany (Argentina)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RRL",
+    "locale": "rmn_x_rrl",
+    "vernacular": "Romany (Arli)",
+    "script": "ROMAN",
+    "name": "Romany (Arli)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RBH",
+    "locale": "rmn_x_rbh",
+    "vernacular": "Romany (Bosnia and Herzegovina)",
+    "script": "ROMAN",
+    "name": "Romany (Bosnia and Herzegovina)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMY",
+    "locale": "rmn_x_rmy",
+    "vernacular": "ромски (централна България)",
+    "script": "ROMAN",
+    "name": "Romany (Central Bulgaria)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMH",
+    "locale": "rmy_cl",
+    "vernacular": "Romane Jorajane",
+    "script": "ROMAN",
+    "name": "Romany (Chile)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RNC",
+    "locale": "rmn_x_rnc",
+    "vernacular": "Романи (крымски)",
+    "script": "CYRILLIC",
+    "name": "Romany (Crimea)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMS",
+    "locale": "rmc_sk",
+    "vernacular": "romanes (vichodno Slovačiko)",
+    "script": "ROMAN",
+    "name": "Romany (Eastern Slovakia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMF",
+    "locale": "rmo_fr",
+    "vernacular": "Romanes (Manouche)",
+    "script": "ROMAN",
+    "name": "Romany (France)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMX",
+    "locale": "rmo",
+    "vernacular": "Romanes (Sinti)",
+    "script": "ROMAN",
+    "name": "Romany (Germany)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMK",
+    "locale": "rmy_x_rmk",
+    "vernacular": "хомани (котлярско, Хусыя)",
+    "script": "CYRILLIC",
+    "name": "Romany (Kalderash, Russia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RVK",
+    "locale": "rmy_x_rvk",
+    "vernacular": "Романі (ловарі, чокещі)",
+    "script": "CYRILLIC",
+    "name": "Romany (Lovari, Chokeshi)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LVA",
+    "locale": "rmy_x_lva",
+    "vernacular": "romani (lovári, Ungriko Them)",
+    "script": "ROMAN",
+    "name": "Romany (Lovari, Hungary)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RM",
+    "locale": "rmn_x_rm",
+    "vernacular": "romane (Makedonija)",
+    "script": "ROMAN",
+    "name": "Romany (Macedonia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMC",
+    "locale": "rmn_cyrl",
+    "vernacular": "романе (Македонија) кирилица",
+    "script": "CYRILLIC",
+    "name": "Romany (Macedonia) Cyrillic",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RCK",
+    "locale": "rmy_x_rck",
+    "vernacular": "Romany (Meçkar)",
+    "script": "ROMAN",
+    "name": "Romany (Meçkar)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RVC",
+    "locale": "rmy_x_rvc",
+    "vernacular": "Романи (Молдова) кирилик",
+    "script": "CYRILLIC",
+    "name": "Romany (Moldova) Cyrillic",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMN",
+    "locale": "rmn_x_rmn",
+    "vernacular": "Ρομανί (Βόρεια Ελλάδα)",
+    "script": "GREEK",
+    "name": "Romany (Northern Greece)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMP",
+    "locale": "rml_ru",
+    "vernacular": "романы (русска рома)",
+    "script": "CYRILLIC",
+    "name": "Romany (Northern Russia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMT",
+    "locale": "rml",
+    "vernacular": "romani (Polska Roma)",
+    "script": "ROMAN",
+    "name": "Romany (Poland)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMR",
+    "locale": "rmy",
+    "vernacular": "Rromani (România)",
+    "script": "ROMAN",
+    "name": "Romany (Romania)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RME",
+    "locale": "rmn_x_rme",
+    "vernacular": "Romane (Srbija)",
+    "script": "ROMAN",
+    "name": "Romany (Serbia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMG",
+    "locale": "rmn_x_rmg",
+    "vernacular": "Ρομανί (Νότια Ελλάδα)",
+    "script": "GREEK",
+    "name": "Romany (Southern Greece)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RSP",
+    "locale": "rmn_x_rsp",
+    "vernacular": "Romany (Spoitori)",
+    "script": "ROMAN",
+    "name": "Romany (Spoitori)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMU",
+    "locale": "rmy_ua",
+    "vernacular": "Романі (ромунгри, Україна)",
+    "script": "CYRILLIC",
+    "name": "Romany (Ukraine)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMV",
+    "locale": "rmy_x_rmv",
+    "vernacular": "романи (влахитско, Россия)",
+    "script": "CYRILLIC",
+    "name": "Romany (Vlax, Russia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RMB",
+    "locale": "rmn_x_rmb",
+    "vernacular": "ромски (западна България)",
+    "script": "CYRILLIC",
+    "name": "Romany (Western Bulgaria)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RN",
+    "locale": "rng",
+    "vernacular": "Xironga",
+    "script": "ROMAN",
+    "name": "Ronga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RO",
+    "locale": "rtm",
+    "vernacular": "Rotuạm ta",
+    "script": "ROMAN",
+    "name": "Rotuman",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RV",
+    "locale": "rug",
+    "vernacular": "Roviana",
+    "script": "ROMAN",
+    "name": "Roviana",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RKI",
+    "locale": "dru",
+    "vernacular": "Drekay",
+    "script": "ROMAN",
+    "name": "Rukai",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RNY",
+    "locale": "diu",
+    "vernacular": "Rumanyo",
+    "script": "ROMAN",
+    "name": "Rumanyo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RGS",
+    "locale": "drg",
+    "vernacular": "Momogun",
+    "script": "ROMAN",
+    "name": "Rungus",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RR",
+    "locale": "nyn",
+    "vernacular": "Runyankore",
+    "script": "ROMAN",
+    "name": "Runyankore",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "U",
+    "locale": "ru",
+    "vernacular": "русский",
+    "script": "CYRILLIC",
+    "name": "Russian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RSL",
+    "locale": "rsl",
+    "vernacular": "русский жестовый",
+    "script": "CYRILLIC",
+    "name": "Russian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "RSC",
+    "locale": "rue",
+    "vernacular": "Закарпатська русинська",
+    "script": "CYRILLIC",
+    "name": "Rusyn (Carpathian)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RT",
+    "locale": "ttj",
+    "vernacular": "Rutoro",
+    "script": "ROMAN",
+    "name": "Rutoro",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "RWS",
+    "locale": "sgn_rw",
+    "vernacular": "Ururimi rw'amarenga yo mu Rwanda",
+    "script": "ROMAN",
+    "name": "Rwandan Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "RCR",
+    "locale": "rcf",
+    "vernacular": "Kréol Rénioné",
+    "script": "ROMAN",
+    "name": "Réunion Creole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LP",
+    "locale": "se",
+    "vernacular": "sámegiella (davvi)",
+    "script": "ROMAN",
+    "name": "Saami (North)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SDD",
+    "locale": "sck_deva",
+    "vernacular": "सादरी (देवनागरी)",
+    "script": "DEVANAGARI",
+    "name": "Sadri (Devanagari)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LUC",
+    "locale": "acf",
+    "vernacular": "Kwéyòl (Patwa)",
+    "script": "ROMAN",
+    "name": "Saint Lucian Creole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SAL",
+    "locale": "loe",
+    "vernacular": "Saluan",
+    "script": "ROMAN",
+    "name": "Saluan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SBR",
+    "locale": "saq",
+    "vernacular": "Sampur",
+    "script": "ROMAN",
+    "name": "Samburu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LH",
+    "locale": "lsm",
+    "vernacular": "Samia",
+    "script": "ROMAN",
+    "name": "Samia",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SM",
+    "locale": "sm",
+    "vernacular": "Faa-Samoa",
+    "script": "ROMAN",
+    "name": "Samoan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SMS",
+    "locale": "sgn_ws",
+    "vernacular": "Samoan Sign Language",
+    "script": "ROMAN",
+    "name": "Samoan Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SGA",
+    "locale": "sng",
+    "vernacular": "Kisanga",
+    "script": "ROMAN",
+    "name": "Sanga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SGR",
+    "locale": "sxn",
+    "vernacular": "Sangir",
+    "script": "ROMAN",
+    "name": "Sangir",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SG",
+    "locale": "sg",
+    "vernacular": "Sango",
+    "script": "ROMAN",
+    "name": "Sango",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SHD",
+    "locale": "sat_deva",
+    "vernacular": "Santhali (Devanagari)",
+    "script": "DEVANAGARI",
+    "name": "Santhali (Devanagari)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SHR",
+    "locale": "sat",
+    "vernacular": "Santhali (Roman)",
+    "script": "ROMAN",
+    "name": "Santhali (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SAR",
+    "locale": "mwm",
+    "vernacular": "Sar",
+    "script": "ROMAN",
+    "name": "Sar",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SRM",
+    "locale": "srm",
+    "vernacular": "Saamakatöngö",
+    "script": "ROMAN",
+    "name": "Saramaccan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SRI",
+    "locale": "hns",
+    "vernacular": "Sarnami Hindoestani",
+    "script": "ROMAN",
+    "name": "Sarnami",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SSK",
+    "locale": "sas",
+    "vernacular": "Sasak",
+    "script": "ROMAN",
+    "name": "Sasak",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "STM",
+    "locale": "mav",
+    "vernacular": "Satere Mawe",
+    "script": "ROMAN",
+    "name": "Sateré-Mawé",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "GCS",
+    "locale": "gd",
+    "vernacular": "Gàidhlig",
+    "script": "ROMAN",
+    "name": "Scottish Gaelic",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SDQ",
+    "locale": "trv_x_sdq",
+    "vernacular": "Seediq",
+    "script": "ROMAN",
+    "name": "Seediq",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SHW",
+    "locale": "sfw",
+    "vernacular": "Sehwi",
+    "script": "ROMAN",
+    "name": "Sehwi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SEN",
+    "locale": "seh",
+    "vernacular": "Cisena",
+    "script": "ROMAN",
+    "name": "Sena",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SFC",
+    "locale": "sef",
+    "vernacular": "Senarì",
+    "script": "ROMAN",
+    "name": "Senoufo (Cebaara)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SE",
+    "locale": "nso",
+    "vernacular": "Sepedi",
+    "script": "ROMAN",
+    "name": "Sepedi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SPL",
+    "locale": "nso_x_spl",
+    "vernacular": "Sepulana",
+    "script": "ROMAN",
+    "name": "Sepulana",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SB",
+    "locale": "sr_cyrl",
+    "vernacular": "српски (ћирилица)",
+    "script": "CYRILLIC",
+    "name": "Serbian (Cyrillic)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SBO",
+    "locale": "sr_latn",
+    "vernacular": "srpski (latinica)",
+    "script": "ROMAN",
+    "name": "Serbian (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SBS",
+    "locale": "sgn_rs",
+    "vernacular": "srpski znakovni jezik",
+    "script": "CYRILLIC",
+    "name": "Serbian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "ER",
+    "locale": "srr",
+    "vernacular": "Seereer",
+    "script": "ROMAN",
+    "name": "Serer",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SU",
+    "locale": "st",
+    "vernacular": "Sesotho (Lesotho)",
+    "script": "ROMAN",
+    "name": "Sesotho (Lesotho)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SSA",
+    "locale": "st_za",
+    "vernacular": "Sesotho (South Africa)",
+    "script": "ROMAN",
+    "name": "Sesotho (South Africa)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TN",
+    "locale": "tn",
+    "vernacular": "Setswana",
+    "script": "ROMAN",
+    "name": "Setswana",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SC",
+    "locale": "crs",
+    "vernacular": "Kreol Seselwa",
+    "script": "ROMAN",
+    "name": "Seychelles Creole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SHA",
+    "locale": "shn",
+    "vernacular": "Shan",
+    "script": "MYANMAR",
+    "name": "Shan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HWI",
+    "locale": "cbt",
+    "vernacular": "shawi",
+    "script": "ROMAN",
+    "name": "Shawi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SL",
+    "locale": "shk",
+    "vernacular": "Dhøg Cøllø",
+    "script": "ROMAN",
+    "name": "Shilluk",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SHC",
+    "locale": "shp",
+    "vernacular": "shipibo-conibo",
+    "script": "ROMAN",
+    "name": "Shipibo-Conibo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CA",
+    "locale": "sn",
+    "vernacular": "Shona",
+    "script": "ROMAN",
+    "name": "Shona",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SHU",
+    "locale": "jiv",
+    "vernacular": "shuar",
+    "script": "ROMAN",
+    "name": "Shuar",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SGH",
+    "locale": "sgh",
+    "vernacular": "шуғнонӣ",
+    "script": "CYRILLIC",
+    "name": "Shughni",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DM",
+    "locale": "sid",
+    "vernacular": "Sidaamu Afoo",
+    "script": "ROMAN",
+    "name": "Sidama",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SSN",
+    "locale": "szl",
+    "vernacular": "jynzyk Ślónska Cieszyńskigo",
+    "script": "ROMAN",
+    "name": "Silesian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SK",
+    "locale": "loz",
+    "vernacular": "Silozi",
+    "script": "ROMAN",
+    "name": "Silozi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NDV",
+    "locale": "sd_deva",
+    "vernacular": "Sindhi (Devanagari)",
+    "script": "DEVANAGARI",
+    "name": "Sindhi (Devanagari)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "NDN",
+    "locale": "snd_x_ndn",
+    "vernacular": "Sindhi (Indonesia)",
+    "script": "ROMAN",
+    "name": "Sindhi (Indonesia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SGL",
+    "locale": "sls",
+    "vernacular": "Singapore Sign Language",
+    "script": "ROMAN",
+    "name": "Singapore Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SN",
+    "locale": "si",
+    "vernacular": "සිංහල",
+    "script": "SINHALESE",
+    "name": "Sinhala",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "V",
+    "locale": "sk",
+    "vernacular": "slovenčina",
+    "script": "ROMAN",
+    "name": "Slovak",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "VSL",
+    "locale": "svk",
+    "vernacular": "slovenský posunkový jazyk",
+    "script": "ROMAN",
+    "name": "Slovak Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SV",
+    "locale": "sl",
+    "vernacular": "slovenščina",
+    "script": "ROMAN",
+    "name": "Slovenian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SZJ",
+    "locale": "sgn_si",
+    "vernacular": "slovenski znakovni jezik",
+    "script": "ROMAN",
+    "name": "Slovenian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SOL",
+    "locale": "sby",
+    "vernacular": "Cisoli",
+    "script": "ROMAN",
+    "name": "Soli",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SP",
+    "locale": "pis",
+    "vernacular": "Solomon Islands Pidgin",
+    "script": "ROMAN",
+    "name": "Solomon Islands Pidgin",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SO",
+    "locale": "so",
+    "vernacular": "Soomaali",
+    "script": "ROMAN",
+    "name": "Somali",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SGO",
+    "locale": "nsx",
+    "vernacular": "Songo",
+    "script": "ROMAN",
+    "name": "Songo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SGM",
+    "locale": "soe",
+    "vernacular": "Losongomino",
+    "script": "ROMAN",
+    "name": "Songomeno",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SNK",
+    "locale": "snk",
+    "vernacular": "Soninke",
+    "script": "ROMAN",
+    "name": "Soninke",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SAS",
+    "locale": "sfs",
+    "vernacular": "South African Sign Language",
+    "script": "ROMAN",
+    "name": "South African Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SSP",
+    "locale": "es_es",
+    "vernacular": "español (de&nbsp;España)",
+    "script": "ROMAN",
+    "name": "Spanish (Spain)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SR",
+    "locale": "srn",
+    "vernacular": "Sranantongo",
+    "script": "ROMAN",
+    "name": "Sranantongo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SLS",
+    "locale": "sqs",
+    "vernacular": "ශ්‍රී ලංකා සංඥා භාෂාව",
+    "script": "SINHALESE",
+    "name": "Sri Lankan Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "UK",
+    "locale": "suk",
+    "vernacular": "Kisukuma",
+    "script": "ROMAN",
+    "name": "Sukuma",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SD",
+    "locale": "su",
+    "vernacular": "Sunda",
+    "script": "ROMAN",
+    "name": "Sunda",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ODN",
+    "locale": "ory_x_odn",
+    "vernacular": "Sundargadi",
+    "script": "ROMAN",
+    "name": "Sundargadi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SRG",
+    "locale": "sgd",
+    "vernacular": "Surigaonon",
+    "script": "ROMAN",
+    "name": "Surigaonon",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SSU",
+    "locale": "sgn_sr",
+    "vernacular": "Surinaamse Gebarentaal",
+    "script": "ROMAN",
+    "name": "Suriname Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SUS",
+    "locale": "sus",
+    "vernacular": "Soso xui",
+    "script": "ROMAN",
+    "name": "Susu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SVL",
+    "locale": "sva_x_svl",
+    "vernacular": "ჩუბე ლუშვანუ",
+    "script": "GEORGIAN",
+    "name": "Svan (Lower)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SVN",
+    "locale": "sva_x_svn",
+    "vernacular": "ჟიბე ლუშნუ",
+    "script": "GEORGIAN",
+    "name": "Svan (Upper)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SW",
+    "locale": "sw",
+    "vernacular": "Kiswahili",
+    "script": "ROMAN",
+    "name": "Swahili",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZS",
+    "locale": "swc",
+    "vernacular": "Kiswahili (Congo)",
+    "script": "ROMAN",
+    "name": "Swahili (Congo)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SWK",
+    "locale": "swc_x_swk",
+    "vernacular": "Swahili (Katanga)",
+    "script": "ROMAN",
+    "name": "Swahili (Katanga)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SWI",
+    "locale": "ss",
+    "vernacular": "SiSwati",
+    "script": "ROMAN",
+    "name": "Swati",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SWS",
+    "locale": "sgn_sz",
+    "vernacular": "Swazi Sign Language",
+    "script": "ROMAN",
+    "name": "Swazi Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "Z",
+    "locale": "sv",
+    "vernacular": "Svenska",
+    "script": "ROMAN",
+    "name": "Swedish",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SSL",
+    "locale": "swl",
+    "vernacular": "Svenskt teckenspråk",
+    "script": "ROMAN",
+    "name": "Swedish Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "XSW",
+    "locale": "gsw",
+    "vernacular": "Schweizerdeutsch",
+    "script": "ROMAN",
+    "name": "Swiss German",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SGS",
+    "locale": "sgg",
+    "vernacular": "Deutschschweizer Gebärdensprache",
+    "script": "ROMAN",
+    "name": "Swiss German Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SYL",
+    "locale": "syl_x_syl",
+    "vernacular": "সেলেটি (বাংলা)",
+    "script": "BENGALI",
+    "name": "Sylheti (Bengali)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "STN",
+    "locale": "cri",
+    "vernacular": "Santome",
+    "script": "ROMAN",
+    "name": "Sãotomense",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TBW",
+    "locale": "tap",
+    "vernacular": "Taabwa",
+    "script": "ROMAN",
+    "name": "Taabwa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TBN",
+    "locale": "tab",
+    "vernacular": "табасаран",
+    "script": "CYRILLIC",
+    "name": "Tabasaran",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TG",
+    "locale": "tl",
+    "vernacular": "Tagalog",
+    "script": "ROMAN",
+    "name": "Tagalog",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TH",
+    "locale": "ty",
+    "vernacular": "Tahiti",
+    "script": "ROMAN",
+    "name": "Tahitian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "KE",
+    "locale": "uar",
+    "vernacular": "Tairuma",
+    "script": "ROMAN",
+    "name": "Tairuma",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AT",
+    "locale": "dav",
+    "vernacular": "Kidawida",
+    "script": "ROMAN",
+    "name": "Taita",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TSL",
+    "locale": "tss",
+    "vernacular": "台灣手語",
+    "script": "CHINESE",
+    "name": "Taiwanese Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "TJ",
+    "locale": "tg",
+    "vernacular": "тоҷикӣ",
+    "script": "CYRILLIC",
+    "name": "Tajiki",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TJU",
+    "locale": "tg_uz",
+    "vernacular": "тоҷикӣ (Самарқанд)",
+    "script": "CYRILLIC",
+    "name": "Tajiki (Samarkand)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TAL",
+    "locale": "vec",
+    "vernacular": "Talian",
+    "script": "ROMAN",
+    "name": "Talian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TLY",
+    "locale": "tly_x_tly",
+    "vernacular": "Toloş",
+    "script": "ROMAN",
+    "name": "Talysh",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TME",
+    "locale": "taj",
+    "vernacular": "Tamang (Eastern)",
+    "script": "ROMAN",
+    "name": "Tamang (Eastern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TMW",
+    "locale": "tdj",
+    "vernacular": "Tamang (Western)",
+    "script": "ROMAN",
+    "name": "Tamang (Western)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TL",
+    "locale": "ta",
+    "vernacular": "தமிழ்",
+    "script": "TAMIL",
+    "name": "Tamil",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TLR",
+    "locale": "ta_x_tlr",
+    "vernacular": "Thamil (Rōman)",
+    "script": "ROMAN",
+    "name": "Tamil (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TND",
+    "locale": "tdx",
+    "vernacular": "Tandroy",
+    "script": "ROMAN",
+    "name": "Tandroy",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TT",
+    "locale": "nmf",
+    "vernacular": "Tangkhul",
+    "script": "ROMAN",
+    "name": "Tangkhul",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TNK",
+    "locale": "xmv",
+    "vernacular": "Tankarana",
+    "script": "ROMAN",
+    "name": "Tankarana",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TZL",
+    "locale": "tza",
+    "vernacular": "Lugha ya Alama ya Tanzania",
+    "script": "ROMAN",
+    "name": "Tanzanian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "TRH",
+    "locale": "tar",
+    "vernacular": "ralámuli",
+    "script": "ROMAN",
+    "name": "Tarahumara (Central)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TRW",
+    "locale": "tac",
+    "vernacular": "tarahumara occidental",
+    "script": "ROMAN",
+    "name": "Tarahumara (Western)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TRS",
+    "locale": "tsz",
+    "vernacular": "Purépecha",
+    "script": "ROMAN",
+    "name": "Tarascan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YG",
+    "locale": "yer",
+    "vernacular": "Tarok",
+    "script": "ROMAN",
+    "name": "Tarok",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TRK",
+    "locale": "trv_x_trk",
+    "vernacular": "Truku",
+    "script": "ROMAN",
+    "name": "Taroko",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TAT",
+    "locale": "tt",
+    "vernacular": "татар",
+    "script": "CYRILLIC",
+    "name": "Tatar",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TA",
+    "locale": "tsg",
+    "vernacular": "Tausug",
+    "script": "ROMAN",
+    "name": "Tausug",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TU",
+    "locale": "te",
+    "vernacular": "తెలుగు",
+    "script": "TELUGU",
+    "name": "Telugu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TEM",
+    "locale": "kdh",
+    "vernacular": "Kotokoli",
+    "script": "ROMAN",
+    "name": "Tem",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CHD",
+    "locale": "nan_x_chd",
+    "vernacular": "潮州",
+    "script": "CHINESE",
+    "name": "Teochew",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TWD",
+    "locale": "nan_x_twd",
+    "vernacular": "Teochew (Indonesia)",
+    "script": "ROMAN",
+    "name": "Teochew (Indonesia)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TER",
+    "locale": "ter",
+    "vernacular": "Terêna",
+    "script": "ROMAN",
+    "name": "Terêna",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TTB",
+    "locale": "tet",
+    "vernacular": "Tetun Belu",
+    "script": "ROMAN",
+    "name": "Tetun Belu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TTP",
+    "locale": "tdt",
+    "vernacular": "Tetun Dili",
+    "script": "ROMAN",
+    "name": "Tetun Dili",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TEW",
+    "locale": "twx",
+    "vernacular": "Ciutee",
+    "script": "ROMAN",
+    "name": "Tewe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SI",
+    "locale": "th",
+    "vernacular": "ไทย",
+    "script": "THAI",
+    "name": "Thai",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SIK",
+    "locale": "th_x_sik",
+    "vernacular": "ไทย (โคราช)",
+    "script": "THAI",
+    "name": "Thai (Korat)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SIE",
+    "locale": "tts",
+    "vernacular": "อีสาน",
+    "script": "THAI",
+    "name": "Thai (Northeastern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SIR",
+    "locale": "nod",
+    "vernacular": "กำเมือง",
+    "script": "THAI",
+    "name": "Thai (Northern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SIS",
+    "locale": "sou",
+    "vernacular": "ไทย (ใต้)",
+    "script": "THAI",
+    "name": "Thai (Southern)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SIL",
+    "locale": "tsq",
+    "vernacular": "ภาษามือไทย",
+    "script": "THAI",
+    "name": "Thai Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "SIG",
+    "locale": "soa",
+    "vernacular": "ไทยซ้ง",
+    "script": "THAI",
+    "name": "Thai Song",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TMN",
+    "locale": "tem",
+    "vernacular": "Themne",
+    "script": "ROMAN",
+    "name": "Themne",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TBT",
+    "locale": "bo",
+    "vernacular": "བོད་སྐད།",
+    "script": "TIBETAN",
+    "name": "Tibetan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TCN",
+    "locale": "tca",
+    "vernacular": "Ticuna",
+    "script": "ROMAN",
+    "name": "Ticuna",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TI",
+    "locale": "ti",
+    "vernacular": "ትግርኛ",
+    "script": "ETHIOPIC",
+    "name": "Tigrinya",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TII",
+    "locale": "txq",
+    "vernacular": "Rote Tii",
+    "script": "ROMAN",
+    "name": "Tii",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TV",
+    "locale": "tiv",
+    "vernacular": "Tiv",
+    "script": "ROMAN",
+    "name": "Tiv",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TLN",
+    "locale": "tcf",
+    "vernacular": "me̱ʼpha̱a̱",
+    "script": "ROMAN",
+    "name": "Tlapanec",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OB",
+    "locale": "mlu",
+    "vernacular": "Toabaita",
+    "script": "ROMAN",
+    "name": "To'abaita",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TR",
+    "locale": "tqo",
+    "vernacular": "Toaripi",
+    "script": "ROMAN",
+    "name": "Toaripi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TOB",
+    "locale": "tob",
+    "vernacular": "toba",
+    "script": "ROMAN",
+    "name": "Toba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TGS",
+    "locale": "sgn_tg",
+    "vernacular": "Togo Sign Language",
+    "script": "ROMAN",
+    "name": "Togo Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "TJO",
+    "locale": "toj",
+    "vernacular": "tojol-abʼal",
+    "script": "ROMAN",
+    "name": "Tojolabal",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "MP",
+    "locale": "tpi",
+    "vernacular": "Tok Pisin",
+    "script": "ROMAN",
+    "name": "Tok Pisin",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "OE",
+    "locale": "tkl",
+    "vernacular": "Faka-Tokelau",
+    "script": "ROMAN",
+    "name": "Tokelauan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TO",
+    "locale": "to",
+    "vernacular": "Faka-Tonga",
+    "script": "ROMAN",
+    "name": "Tongan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TOR",
+    "locale": "sda",
+    "vernacular": "Toraja",
+    "script": "ROMAN",
+    "name": "Toraja",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TSC",
+    "locale": "tcs",
+    "vernacular": "Tores Streit Kriol",
+    "script": "ROMAN",
+    "name": "Torres Strait Creole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TOT",
+    "locale": "top",
+    "vernacular": "totonaco",
+    "script": "ROMAN",
+    "name": "Totonac",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TPR",
+    "locale": "tui",
+    "vernacular": "Toupouri",
+    "script": "ROMAN",
+    "name": "Toupouri",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TTS",
+    "locale": "lst",
+    "vernacular": "Trinidad and Tobago Sign Language",
+    "script": "ROMAN",
+    "name": "Trinidad and Tobago Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "TRC",
+    "locale": "trf",
+    "vernacular": "Trinidadian Creole",
+    "script": "ROMAN",
+    "name": "Trinidadian Creole",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SH",
+    "locale": "lua",
+    "vernacular": "Tshiluba",
+    "script": "ROMAN",
+    "name": "Tshiluba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "AW",
+    "locale": "tsc",
+    "vernacular": "ciTshwa",
+    "script": "ROMAN",
+    "name": "Tshwa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TSM",
+    "locale": "cas",
+    "vernacular": "Tsimané",
+    "script": "ROMAN",
+    "name": "Tsimané",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TMH",
+    "locale": "xmw",
+    "vernacular": "Tsimihety",
+    "script": "ROMAN",
+    "name": "Tsimihety",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TS",
+    "locale": "ts",
+    "vernacular": "Xitsonga",
+    "script": "ROMAN",
+    "name": "Tsonga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TUO",
+    "locale": "tuo",
+    "vernacular": "Dahse ye",
+    "script": "ROMAN",
+    "name": "Tucano",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TLU",
+    "locale": "tcy",
+    "vernacular": "ತುಳು",
+    "script": "KANNADA",
+    "name": "Tulu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TNN",
+    "locale": "tvu",
+    "vernacular": "Banen",
+    "script": "ROMAN",
+    "name": "Tunen",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TRN",
+    "locale": "tuv",
+    "vernacular": "Ng'aturkana",
+    "script": "ROMAN",
+    "name": "Turkana",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TK",
+    "locale": "tr",
+    "vernacular": "Türkçe",
+    "script": "ROMAN",
+    "name": "Turkish",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TKM",
+    "locale": "tur_x_tkm",
+    "vernacular": "ахыска",
+    "script": "ROMAN",
+    "name": "Turkish (Meskhetian)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TKL",
+    "locale": "tsm",
+    "vernacular": "Türk İşaret Dili",
+    "script": "ROMAN",
+    "name": "Turkish Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "TMR",
+    "locale": "tk",
+    "vernacular": "türkmen",
+    "script": "ROMAN",
+    "name": "Turkmen",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TM",
+    "locale": "tk_cyrl",
+    "vernacular": "түркмен (кириллица)",
+    "script": "CYRILLIC",
+    "name": "Turkmen (Cyrillic)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "VL",
+    "locale": "tvl",
+    "vernacular": "Tuvalu",
+    "script": "ROMAN",
+    "name": "Tuvaluan",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "VI",
+    "locale": "tyv",
+    "vernacular": "тыва",
+    "script": "CYRILLIC",
+    "name": "Tuvinian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TW",
+    "locale": "tw",
+    "vernacular": "Twi",
+    "script": "ROMAN",
+    "name": "Twi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TYW",
+    "locale": "car_x_tyw",
+    "vernacular": "Tilewuyu",
+    "script": "ROMAN",
+    "name": "Tyrewuju",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TZE",
+    "locale": "tzh",
+    "vernacular": "tseltal",
+    "script": "ROMAN",
+    "name": "Tzeltal",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TZO",
+    "locale": "tzo",
+    "vernacular": "tsotsil",
+    "script": "ROMAN",
+    "name": "Tzotzil",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "TZU",
+    "locale": "tzj",
+    "vernacular": "tzʼutujil",
+    "script": "ROMAN",
+    "name": "Tzutujil",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "UBM",
+    "locale": "aoz",
+    "vernacular": "Timor Dawan",
+    "script": "ROMAN",
+    "name": "Uab Meto",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "UM",
+    "locale": "udm",
+    "vernacular": "удмурт",
+    "script": "CYRILLIC",
+    "name": "Udmurt",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "USL",
+    "locale": "ugn",
+    "vernacular": "Ugandan Sign Language",
+    "script": "ROMAN",
+    "name": "Ugandan Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "UGA",
+    "locale": "ug_x_uga",
+    "vernacular": "ئۇيغۇر تىلى ‏(‏ئەرەب يېزىقى‏)‏‏‏‏",
+    "script": "ARABIC",
+    "name": "Uighur (Arabic)",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "UG",
+    "locale": "ug_cyrl",
+    "vernacular": "Уйғур (кирилл йезиғи)",
+    "script": "CYRILLIC",
+    "name": "Uighur (Cyrillic)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "K",
+    "locale": "uk",
+    "vernacular": "українська",
+    "script": "CYRILLIC",
+    "name": "Ukrainian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "UB",
+    "locale": "umb",
+    "vernacular": "Umbundu",
+    "script": "ROMAN",
+    "name": "Umbundu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "UD",
+    "locale": "ur",
+    "vernacular": "اُردو",
+    "script": "URDU",
+    "name": "Urdu",
+    "isSignLanguage": false,
+    "isRTL": true
+  },
+  {
+    "code": "UR",
+    "locale": "urh",
+    "vernacular": "Urhobo",
+    "script": "ROMAN",
+    "name": "Urhobo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "URP",
+    "locale": "upv",
+    "vernacular": "Uripiv",
+    "script": "ROMAN",
+    "name": "Uripiv",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "DR",
+    "locale": "rnd",
+    "vernacular": "Uruund",
+    "script": "ROMAN",
+    "name": "Uruund",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "UZ",
+    "locale": "uz_cyrl",
+    "vernacular": "ўзбекча",
+    "script": "CYRILLIC",
+    "name": "Uzbek",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "UZH",
+    "locale": "uzn_x_uzh",
+    "vernacular": "ўзбекча (хоразм шеваси)",
+    "script": "CYRILLIC",
+    "name": "Uzbek (Horezm)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "UZR",
+    "locale": "uz_latn",
+    "vernacular": "o‘zbekcha (lotincha)",
+    "script": "ROMAN",
+    "name": "Uzbek (Roman)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "VLC",
+    "locale": "ca_x_vlc",
+    "vernacular": "valencià",
+    "script": "ROMAN",
+    "name": "Valencian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "VE",
+    "locale": "ve",
+    "vernacular": "Luvenda",
+    "script": "ROMAN",
+    "name": "Venda",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "VZ",
+    "locale": "skg_x_vz",
+    "vernacular": "Vezo",
+    "script": "ROMAN",
+    "name": "Vezo",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "VRU",
+    "locale": "vro",
+    "vernacular": "võro",
+    "script": "ROMAN",
+    "name": "Voru",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WAM",
+    "locale": "prk",
+    "vernacular": "Vax",
+    "script": "ROMAN",
+    "name": "Wa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WMM",
+    "locale": "wwa",
+    "vernacular": "Waama",
+    "script": "ROMAN",
+    "name": "Waama",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WA",
+    "locale": "wls",
+    "vernacular": "Faka'uvea",
+    "script": "ROMAN",
+    "name": "Wallisian",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "LW",
+    "locale": "lwg",
+    "vernacular": "Kiwanga",
+    "script": "ROMAN",
+    "name": "Wanga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WPH",
+    "locale": "wap",
+    "vernacular": "Wapichana",
+    "script": "ROMAN",
+    "name": "Wapishana",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WRO",
+    "locale": "wba",
+    "vernacular": "warao",
+    "script": "ROMAN",
+    "name": "Warao",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "SA",
+    "locale": "war",
+    "vernacular": "Waray-Waray",
+    "script": "ROMAN",
+    "name": "Waray-Waray",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WY",
+    "locale": "guc",
+    "vernacular": "Wayuunaiki",
+    "script": "ROMAN",
+    "name": "Wayuunaiki",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WJW",
+    "locale": "wew",
+    "vernacular": "Wejewa (Sumba Barat)",
+    "script": "ROMAN",
+    "name": "Wejewa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "W",
+    "locale": "cy",
+    "vernacular": "Cymraeg",
+    "script": "ROMAN",
+    "name": "Welsh",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WCH",
+    "locale": "mzh",
+    "vernacular": "wichí",
+    "script": "ROMAN",
+    "name": "Wichi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WCB",
+    "locale": "wlv",
+    "vernacular": "Wichi (Bermejo)",
+    "script": "ROMAN",
+    "name": "Wichi (Bermejo)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "HCH",
+    "locale": "hch",
+    "vernacular": "wixárika",
+    "script": "ROMAN",
+    "name": "Wixárika",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WL",
+    "locale": "wal",
+    "vernacular": "Wolayttattuwa",
+    "script": "ROMAN",
+    "name": "Wolaita",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "WO",
+    "locale": "wo",
+    "vernacular": "wolof",
+    "script": "ROMAN",
+    "name": "Wolof",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "XV",
+    "locale": "xav",
+    "vernacular": "A'uwẽ mreme",
+    "script": "ROMAN",
+    "name": "Xavante",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "XO",
+    "locale": "xh",
+    "vernacular": "IsiXhosa",
+    "script": "ROMAN",
+    "name": "Xhosa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "XRC",
+    "locale": "ane",
+    "vernacular": "Xârâcùù",
+    "script": "ROMAN",
+    "name": "Xârâcùù",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YCB",
+    "locale": "daf",
+    "vernacular": "Yaoba",
+    "script": "ROMAN",
+    "name": "Yacouba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YAK",
+    "locale": "yaf",
+    "vernacular": "Iyaka",
+    "script": "ROMAN",
+    "name": "Yaka",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YKM",
+    "locale": "yky",
+    "vernacular": "Yakoma",
+    "script": "ROMAN",
+    "name": "Yakoma",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YK",
+    "locale": "sah",
+    "vernacular": "сахалыы",
+    "script": "CYRILLIC",
+    "name": "Yakutsk",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YBS",
+    "locale": "yas",
+    "vernacular": "Yambassa",
+    "script": "ROMAN",
+    "name": "Yambassa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YMI",
+    "locale": "tao",
+    "vernacular": "Yami",
+    "script": "ROMAN",
+    "name": "Yami",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YNS",
+    "locale": "yns",
+    "vernacular": "Iyanzi",
+    "script": "ROMAN",
+    "name": "Yansi",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YP",
+    "locale": "yap",
+    "vernacular": "Waab",
+    "script": "ROMAN",
+    "name": "Yapese",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YQ",
+    "locale": "yaq",
+    "vernacular": "jiiak noki",
+    "script": "ROMAN",
+    "name": "Yaqui",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "BM",
+    "locale": "ybb",
+    "vernacular": "Dschang",
+    "script": "ROMAN",
+    "name": "Yemba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YMB",
+    "locale": "yom_x_ymb",
+    "vernacular": "Yombe",
+    "script": "ROMAN",
+    "name": "Yombe",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YN",
+    "locale": "yno",
+    "vernacular": "Yong",
+    "script": "THAI",
+    "name": "Yong",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YR",
+    "locale": "yo",
+    "vernacular": "Yorùbá",
+    "script": "ROMAN",
+    "name": "Yoruba",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YNG",
+    "locale": "nua",
+    "vernacular": "Yuanga",
+    "script": "ROMAN",
+    "name": "Yuanga",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "YKP",
+    "locale": "yup",
+    "vernacular": "yukpa",
+    "script": "ROMAN",
+    "name": "Yukpa",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZAS",
+    "locale": "zsl",
+    "vernacular": "Zambian Sign Language",
+    "script": "ROMAN",
+    "name": "Zambian Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "ZN",
+    "locale": "zne",
+    "vernacular": "Zande",
+    "script": "ROMAN",
+    "name": "Zande",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZPG",
+    "locale": "zpg",
+    "vernacular": "dîdzrie’",
+    "script": "ROMAN",
+    "name": "Zapotec (Guevea)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZPI",
+    "locale": "zai",
+    "vernacular": "diidxazá",
+    "script": "ROMAN",
+    "name": "Zapotec (Isthmus)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZPX",
+    "locale": "zpd",
+    "vernacular": "Dillexhon",
+    "script": "ROMAN",
+    "name": "Zapotec (Ixtlán)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZPL",
+    "locale": "zpa",
+    "vernacular": "diitza",
+    "script": "ROMAN",
+    "name": "Zapotec (Lachiguiri)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZPM",
+    "locale": "ztp",
+    "vernacular": "diʼste Loxich",
+    "script": "ROMAN",
+    "name": "Zapotec (Loxicha)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZPT",
+    "locale": "zpf",
+    "vernacular": "zapoteco de Quiatoni",
+    "script": "ROMAN",
+    "name": "Zapotec (Quiatoni)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZPC",
+    "locale": "zpj",
+    "vernacular": "ditz zea",
+    "script": "ROMAN",
+    "name": "Zapotec (Quiavicuzas)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZPS",
+    "locale": "zpr",
+    "vernacular": "Zapotec (Santiago Xanica)",
+    "script": "ROMAN",
+    "name": "Zapotec (Santiago Xanica)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZPV",
+    "locale": "zav",
+    "vernacular": "didza xhidza",
+    "script": "ROMAN",
+    "name": "Zapotec (Villa Alta)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZPD",
+    "locale": "zab",
+    "vernacular": "ditsa",
+    "script": "ROMAN",
+    "name": "Zapotec (del Valle)",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZR",
+    "locale": "dje",
+    "vernacular": "Zarma",
+    "script": "ROMAN",
+    "name": "Zarma",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "ZSL",
+    "locale": "zib",
+    "vernacular": "Zimbabwe Sign Language",
+    "script": "ROMAN",
+    "name": "Zimbabwe Sign Language",
+    "isSignLanguage": true,
+    "isRTL": false
+  },
+  {
+    "code": "ZU",
+    "locale": "zu",
+    "vernacular": "IsiZulu",
+    "script": "ROMAN",
+    "name": "Zulu",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
+    "code": "CHX",
+    "locale": "nan_x_chx",
+    "vernacular": "中文（海南话）",
+    "script": "ROMAN",
+    "name": "中文（海南话）",
+    "isSignLanguage": false,
+    "isRTL": false
+  }
+]

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import {
   type ContentSelection,
 } from '@/utils/insertBibleQuotes';
 import { logger } from '@/utils/logger';
+import { getBookLanguage } from './utils/signLanguage';
 
 export const DEFAULT_STYLES: LinkStyles = {
   bookLength: 'medium',
@@ -100,7 +101,7 @@ export default class JWLibraryLinkerPlugin extends Plugin {
     );
 
     // Load bible books for saved language
-    loadBibleBooks(this.settings.language);
+    loadBibleBooks(getBookLanguage(this.settings.language));
 
     // Add settings tab
     this.addSettingTab(new JWLibraryLinkerSettings(this.app, this));

--- a/src/stores/bibleBooks.ts
+++ b/src/stores/bibleBooks.ts
@@ -1,5 +1,6 @@
 import { chapterCounts } from '@/consts/chapterCounts';
 import type { BibleBook, Language } from '@/types';
+import { getBookLanguage } from '@/utils/signLanguage';
 import BUNDLED_LOCALES from 'locale:all';
 import { logger } from '@/utils/logger';
 
@@ -27,20 +28,22 @@ export function __getCache(): Map<Language, readonly BibleBookWithoutChapters[]>
  * @throws Error if loading fails
  */
 export function loadBibleBooks(language: Language): void {
+  const bookLanguage = getBookLanguage(language);
+
   // Return early if already loaded
-  if (booksCache.has(language)) {
+  if (booksCache.has(bookLanguage)) {
     return;
   }
 
-  const bibleFile = `locale/bibleBooks/${language}.yaml`;
+  const bibleFile = `locale/bibleBooks/${bookLanguage}.yaml`;
 
   if (!(bibleFile in BUNDLED_LOCALES)) {
-    logger.error(`Bible books for language ${language} not found in bundle`);
+    logger.error(`Bible books for language ${bookLanguage} not found in bundle`);
     throw new Error('errors.unsupportedLanguage');
   }
 
   const books = BUNDLED_LOCALES[bibleFile] as readonly BibleBookWithoutChapters[];
-  booksCache.set(language, books);
+  booksCache.set(bookLanguage, books);
 }
 
 /**
@@ -52,13 +55,17 @@ export function loadBibleBooks(language: Language): void {
  * @throws Error if language not loaded
  */
 export function getBibleBooks(language: Language): readonly BibleBook[] {
-  const cached = enrichedBooksCache.get(language);
+  const bookLanguage = getBookLanguage(language);
+
+  const cached = enrichedBooksCache.get(bookLanguage);
   if (cached) return cached;
 
-  const books = booksCache.get(language);
+  const books = booksCache.get(bookLanguage);
 
   if (!books) {
-    logger.error(`Bible books for language ${language} not loaded. Call loadBibleBooks() first.`);
+    logger.error(
+      `Bible books for language ${bookLanguage} not loaded. Call loadBibleBooks() first.`,
+    );
     throw new Error('errors.unsupportedLanguage');
   }
 
@@ -66,7 +73,7 @@ export function getBibleBooks(language: Language): readonly BibleBook[] {
     ...book,
     chapters: chapterCounts[book.id],
   }));
-  enrichedBooksCache.set(language, enriched);
+  enrichedBooksCache.set(bookLanguage, enriched);
   return enriched;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,58 @@
-export type Locale = 'en' | 'de' | 'fi' | 'es' | 'nl' | 'ko' | 'fr' | 'pt' | 'hr' | 'vi'; // obsidian language
+// obsidian language
+export type Locale = 'en' | 'de' | 'fi' | 'es' | 'nl' | 'ko' | 'fr' | 'pt' | 'hr' | 'vi';
 
-export type Language = 'E' | 'X' | 'FI' | 'S' | 'O' | 'KO' | 'F' | 'TPO' | 'C' | 'VT'; // plugin language
+// plugin language
+export type Language =
+  | 'E'
+  | 'X'
+  | 'FI'
+  | 'S'
+  | 'O'
+  | 'KO'
+  | 'F'
+  | 'TPO'
+  | 'C'
+  | 'VT'
+  // Sign languages
+  | 'ASL'
+  | 'LSA'
+  | 'AUS'
+  | 'OGS'
+  | 'SBF'
+  | 'BVL'
+  | 'BSL'
+  | 'BFL'
+  | 'CRS'
+  | 'SCH'
+  | 'LSC'
+  | 'SCR'
+  | 'HZJ'
+  | 'CBS'
+  | 'NGT'
+  | 'SEC'
+  | 'FID'
+  | 'LSF'
+  | 'DGS'
+  | 'LSG'
+  | 'SHO'
+  | 'ISG'
+  | 'LSI'
+  | 'JML'
+  | 'KSL'
+  | 'CML'
+  | 'LSM'
+  | 'NZS'
+  | 'LSN'
+  | 'PSL'
+  | 'LSP'
+  | 'SPE'
+  | 'LGP'
+  | 'LSQ'
+  | 'LSS'
+  | 'LSE'
+  | 'LSU'
+  | 'LSV'
+  | 'SLV';
 
 export interface LanguageInfo {
   code: string;

--- a/src/utils/insertBibleQuotes.ts
+++ b/src/utils/insertBibleQuotes.ts
@@ -10,6 +10,7 @@ import {
   type ContentSelection,
 } from '@/utils/findJWLibraryLinks';
 import { logger } from '@/utils/logger';
+import { getBookLanguage } from './signLanguage';
 
 export type { JWLibraryLinkInfo, ContentSelection };
 
@@ -34,7 +35,10 @@ async function generateBibleQuoteText(
 ): Promise<string | null> {
   try {
     logger.log('generateBibleQuoteText: fetching text for', linkInfo.reference);
-    const result = await provider.getCitation(linkInfo.reference, settings.language);
+    const result = await provider.getCitation(
+      linkInfo.reference,
+      getBookLanguage(settings.language),
+    );
 
     if (!result.success || !result.text) {
       logger.warn(

--- a/src/utils/signLanguage.ts
+++ b/src/utils/signLanguage.ts
@@ -1,0 +1,62 @@
+import type { Language } from '@/types';
+
+/**
+ * Maps sign language codes to the spoken language whose Bible book names they use.
+ * The sign language code itself is still used as the wtlocale URL parameter.
+ */
+export const SIGN_LANGUAGE_MAP: Partial<Record<Language, Language>> = {
+  // English base
+  ASL: 'E',
+  BSL: 'E',
+  AUS: 'E',
+  NZS: 'E',
+  ISG: 'E',
+  JML: 'E',
+  // German base
+  DGS: 'X',
+  OGS: 'X',
+  // Finnish base
+  FID: 'FI',
+  // Spanish base
+  LSM: 'S',
+  LSE: 'S',
+  LSA: 'S',
+  BVL: 'S',
+  SCH: 'S',
+  LSC: 'S',
+  SCR: 'S',
+  CBS: 'S',
+  SEC: 'S',
+  LSG: 'S',
+  SHO: 'S',
+  LSN: 'S',
+  PSL: 'S',
+  LSP: 'S',
+  SPE: 'S',
+  LSS: 'S',
+  LSU: 'S',
+  LSV: 'S',
+  // Dutch base
+  NGT: 'O',
+  // Korean base
+  KSL: 'KO',
+  // Portuguese base
+  LGP: 'TPO',
+  // French base
+  LSF: 'F',
+  SBF: 'F',
+  LSQ: 'F',
+  LSI: 'F',
+  BFL: 'F',
+  CRS: 'F',
+  CML: 'F',
+  // Croatian base
+  HZJ: 'C',
+  // Vietnamese base
+  SLV: 'VT',
+};
+
+/** Returns the language to use for Bible book name lookup, resolving sign languages to their spoken base. */
+export function getBookLanguage(language: Language): Language {
+  return SIGN_LANGUAGE_MAP[language] ?? language;
+}


### PR DESCRIPTION
Sign languages reuse Bible book names from their related spoken language via SIGN_LANGUAGE_MAP in utils/signLanguage.ts, while using their own code as the wtlocale URL parameter.

resolves #227 

based on #257