### PR TITLE
Fix truncated WOL Bible quote extraction

### DIFF
--- a/.changeset/soft-bears-tickle.md
+++ b/.changeset/soft-bears-tickle.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+fix truncated Bible quote insertion for WOL verses split across multiple HTML segments

--- a/src/__tests__/BibleTextFetcher.test.ts
+++ b/src/__tests__/BibleTextFetcher.test.ts
@@ -235,6 +235,36 @@ describe('BibleTextFetcher', () => {
         expect(result.text).toContain('disgusting thing');
         expect(result.text).not.toContain('Judea');
       });
+
+      test('extracts all WOL segments for verse ranges', async () => {
+        const html = `
+          <span id="v23-55-1-1" class="v"><a href="#" class="vl vx vp">55 </a>Kommt, all ihr Durstigen, kommt zum Wasser!</span>
+          <span id="v23-55-1-2" class="v">Ihr, die ihr kein Geld habt, kommt, kauft und esst!</span>
+          <span id="v23-55-1-3" class="v">Ja kommt her, kauft Wein und Milch ohne Geld und ohne Kosten.</span>
+          <span id="v23-55-2-1" class="v"><a href="#" class="vl vx vp">2 </a>Warum bezahlt ihr ständig Geld für etwas, was kein Brot ist,</span>
+          <span id="v23-55-2-2" class="v">und warum gebt ihr euren Verdienst für etwas aus, was nicht satt macht?</span>
+          <span id="v23-55-2-3" class="v">Hört mir aufmerksam zu und esst Gutes,</span>
+          <span id="v23-55-2-4" class="v">und ihr werdet großen Genuss finden an dem, was wirklich gehaltvoll ist.</span>
+          <span id="v23-55-3-1" class="v"><a href="#" class="vl vx vp">3 </a>Neigt euer Ohr und kommt zu mir.</span>
+        `;
+
+        mockedRequestUrl.mockResolvedValue({ status: 200, text: html });
+
+        const result = await BibleTextFetcher.fetchBibleText(
+          {
+            book: 23,
+            chapter: 55,
+            verseRanges: [{ start: 1, end: 2 }],
+          },
+          'X',
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.text).toBe(
+          'Kommt, all ihr Durstigen, kommt zum Wasser! Ihr, die ihr kein Geld habt, kommt, kauft und esst! Ja kommt her, kauft Wein und Milch ohne Geld und ohne Kosten. Warum bezahlt ihr ständig Geld für etwas, was kein Brot ist, und warum gebt ihr euren Verdienst für etwas aus, was nicht satt macht? Hört mir aufmerksam zu und esst Gutes, und ihr werdet großen Genuss finden an dem, was wirklich gehaltvoll ist.',
+        );
+        expect(result.text).not.toContain('Neigt euer Ohr');
+      });
     });
 
     describe('regular verse extraction (verse number displayed)', () => {

--- a/src/services/BibleTextFetcher.ts
+++ b/src/services/BibleTextFetcher.ts
@@ -434,36 +434,36 @@ export class BibleTextFetcher {
     const textParts: string[] = [];
 
     for (let v = start; v <= end; v++) {
-      let verseEl: Element | null = null;
+      const verseElements = isWOL
+        ? Array.from(doc.querySelectorAll(`span[id^="v${book}-${chapter}-${v}-"]`)).sort((a, b) => {
+            const aSegment = Number(a.id.split('-').pop()) || 0;
+            const bSegment = Number(b.id.split('-').pop()) || 0;
+            return aSegment - bSegment;
+          })
+        : (() => {
+            const verseId = `v${book}${padChapter(chapter)}${padVerse(v)}`;
+            const verseEl = doc.getElementById(verseId);
+            return verseEl ? [verseEl] : [];
+          })();
 
-      if (isWOL) {
-        // WOL: verse spans have id="v{book}-{chapter}-{verse}-{segment}"
-        // There may be multiple segments per verse (e.g. v40-24-14-1, v40-24-14-2)
-        verseEl = doc.querySelector(`span[id="v${book}-${chapter}-${v}-1"]`);
-      } else {
-        // jw.org: verse spans have id="v{paddedBook}{paddedChapter}{paddedVerse}"
-        const verseId = `v${book}${padChapter(chapter)}${padVerse(v)}`;
-        verseEl = doc.getElementById(verseId);
-      }
+      for (const verseEl of verseElements) {
+        const clone = verseEl.cloneNode(true) as HTMLElement;
 
-      if (!verseEl) continue;
+        // Remove footnote/cross-reference links (both jw.org and WOL formats)
+        clone.querySelectorAll('a.footnoteLink, a.xrefLink, a.b').forEach((el) => el.remove());
 
-      const clone = verseEl.cloneNode(true) as HTMLElement;
+        // Remove study note sections
+        clone.querySelectorAll('.studyBible, .study-notes, .notes').forEach((el) => el.remove());
 
-      // Remove footnote/cross-reference links (both jw.org and WOL formats)
-      clone.querySelectorAll('a.footnoteLink, a.xrefLink, a.b').forEach((el) => el.remove());
+        // Remove verse number elements
+        clone.querySelectorAll('.chapterNum, .verseNum').forEach((el) => el.remove());
+        // WOL: verse number links have class "vl"
+        clone.querySelectorAll('a.vl').forEach((el) => el.remove());
 
-      // Remove study note sections
-      clone.querySelectorAll('.studyBible, .study-notes, .notes').forEach((el) => el.remove());
-
-      // Remove verse number elements
-      clone.querySelectorAll('.chapterNum, .verseNum').forEach((el) => el.remove());
-      // WOL: verse number links have class "vl"
-      clone.querySelectorAll('a.vl').forEach((el) => el.remove());
-
-      const rawText = cleanHtmlText(clone.innerHTML).trim();
-      if (rawText) {
-        textParts.push(rawText);
+        const rawText = cleanHtmlText(clone.innerHTML).trim();
+        if (rawText) {
+          textParts.push(rawText);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- collect all WOL HTML segments for each requested verse instead of only the first segment
- keep existing cleaning logic while concatenating multi-segment verse text in order
- add a regression test for Isaiah 55:1-2 and a patch changeset

## Testing
- pnpm test -- BibleTextFetcher.test.ts --testNamePattern "extracts all WOL segments for verse ranges"