### PR TITLE
fix: support EPUB locale aliases in import detection

### DIFF
--- a/.changeset/fuzzy-ghosts-ring.md
+++ b/.changeset/fuzzy-ghosts-ring.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+Fix offline Bible EPUB language detection for locale aliases such as Portuguese `pt`, `pt-pt`, and `pt_PT`.

--- a/src/__tests__/offlineBibleCitation.test.ts
+++ b/src/__tests__/offlineBibleCitation.test.ts
@@ -83,4 +83,62 @@ describe('offline Bible citation flow', () => {
 
     await rm(tempDir, { recursive: true, force: true });
   });
+
+  test.each([
+    ['pt', 'TPO'],
+    ['pt-pt', 'TPO'],
+    ['pt_PT', 'TPO'],
+    ['PT-PT', 'TPO'],
+  ] as const)(
+    'detects Portuguese EPUB metadata locale %s as %s',
+    async (epubLanguage, expected) => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'librarylinker-offline-'));
+      const repository = new FileSystemOfflineBibleRepository(join(tempDir, 'offline-bible'));
+      const importer = new BibleEpubImportService(repository);
+      const epubPath = join(tempDir, `nwt_${epubLanguage}.epub`);
+
+      const archive = zipSync({
+        mimetype: strToU8('application/epub+zip'),
+        'META-INF/container.xml': strToU8(`<?xml version="1.0" encoding="utf-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`),
+        'OEBPS/content.opf': strToU8(`<?xml version="1.0" encoding="utf-8"?>
+<package version="3.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookId">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Test Bible</dc:title>
+    <dc:language>${epubLanguage}</dc:language>
+    <meta property="dcterms:modified">2026-04-11T12:00:00Z</meta>
+  </metadata>
+</package>`),
+        'OEBPS/bibleversenav1_1.xhtml': strToU8(`<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <h2>Gênesis 1</h2>
+    <a href="genesis1.xhtml#chapter1_verse1">1</a>
+  </body>
+</html>`),
+        'OEBPS/genesis1.xhtml': strToU8(`<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+  <body>
+    <p><span id="chapter1"></span><span id="chapter1_verse1"></span><span class="w_ch"><strong>1</strong></span> No princípio, Deus criou os céus e a terra.</p>
+  </body>
+</html>`),
+      });
+
+      await writeFile(epubPath, Buffer.from(archive));
+
+      const importResult = await importer.importBible({
+        filePath: epubPath,
+        overwriteExisting: false,
+      });
+
+      expect(importResult.success).toBe(true);
+      expect(importResult.language).toBe(expected);
+
+      await rm(tempDir, { recursive: true, force: true });
+    },
+  );
 });

--- a/src/consts/languages.json
+++ b/src/consts/languages.json
@@ -65,6 +65,7 @@
   {
     "code": "TPO",
     "locale": "pt_pt",
+    "importAliases": ["pt"],
     "vernacular": "Português (Portugal)",
     "script": "ROMAN",
     "name": "Portuguese (Portugal)",

--- a/src/consts/languages.ts
+++ b/src/consts/languages.ts
@@ -15,3 +15,18 @@ export const LANGUAGE_ARRAY = languageJson as LanguageInfoPlus[];
 export const LANGUAGE_LABELS: Record<Language, string> = Object.fromEntries(
   languageJson.map((lang) => [lang.code as Language, lang.vernacular]),
 ) as Record<Language, string>;
+
+function normalizeLocale(locale: string): string {
+  return locale.trim().toLowerCase().replace(/_/g, '-');
+}
+
+export function getLanguageByLocale(locale: string): Language | undefined {
+  const normalizedLocale = normalizeLocale(locale);
+
+  const match = LANGUAGE_ARRAY.find((language) => {
+    const candidates = [language.locale, ...(language.importAliases ?? [])];
+    return candidates.some((candidate) => normalizeLocale(candidate) === normalizedLocale);
+  });
+
+  return match?.code;
+}

--- a/src/consts/languages.ts
+++ b/src/consts/languages.ts
@@ -5,7 +5,7 @@ import languageJson from '@/consts/languages.json';
  * Central language configuration.
  */
 export const LANGUAGES: Record<Language, LanguageInfo> = Object.fromEntries(
-  languageJson.map((lang) => [lang.code as Language, lang as LanguageInfo]),
+  languageJson.map((lang) => [lang.code as Language, lang]),
 ) as Record<Language, LanguageInfo>;
 
 type LanguageInfoPlus = Omit<LanguageInfo, 'code'> & { code: Language };

--- a/src/services/BibleEpubImportService.ts
+++ b/src/services/BibleEpubImportService.ts
@@ -8,7 +8,7 @@ import type {
   OfflineBibleRepository,
 } from '@/types';
 import { unzipSync, strFromU8 } from 'fflate';
-import { LANGUAGE_ARRAY } from '@/consts/languages';
+import { getLanguageByLocale } from '@/consts/languages';
 
 // Node.js modules are lazy-required so this file can be imported on mobile
 // without crashing. All methods in this class are desktop-only.
@@ -230,7 +230,7 @@ export class BibleEpubImportService implements EpubImportService {
       return undefined;
     }
 
-    return LANGUAGE_ARRAY.find((i) => i.locale === languageValue)?.code ?? undefined;
+    return getLanguageByLocale(languageValue);
   }
 
   private readModifiedAt(packageDoc: Document): string | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export type Language =
 export interface LanguageInfo {
   code: string;
   locale: string;
+  importAliases?: string[];
   vernacular: string;
   script: string;
   name: string;


### PR DESCRIPTION
## Summary
- normalize EPUB language metadata before matching
- support locale aliases from centralized language config
- add regression tests for Portuguese locale variants and a changeset

## Testing
- npm run test:lint
- npm run test:types
- npm run test:jest -- offlineBibleCitation