### PR TITLE
Cherry-pick accepted changes from #241

### DIFF
--- a/.changeset/feat-czech-language-support.md
+++ b/.changeset/feat-czech-language-support.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': minor
+---
+
+Add Czech language support (JW Library code `B`). Includes Czech Bible book names, abbreviations, and UI translations.

--- a/.changeset/fix-windows-dev-script.md
+++ b/.changeset/fix-windows-dev-script.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+Fix `pnpm dev` on Windows by using `cross-env` for the `DEBUG` environment variable.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Instantly create, convert, and enrich Bible references with direct links to [JW 
 | Português (Portugal) | TPO  |
 | Hrvatski (Croatian)  | C    |
 | Việt (Vietnamese)    | VT   |
+| Čeština (Czech) | B |
 
 The plugin UI automatically adapts to your Obsidian language setting, and Bible book names are fully translated for each language.
 

--- a/locale/bibleBooks/B.yaml
+++ b/locale/bibleBooks/B.yaml
@@ -1,0 +1,418 @@
+- id: 1
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Mojžíšova
+    medium: 1. Mo.
+    short: 1Mo
+- id: 2
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Mojžíšova
+    medium: 2. Mo.
+    short: 2Mo
+- id: 3
+  prefix: '3'
+  aliases: []
+  name:
+    long: 3. Mojžíšova
+    medium: 3. Mo.
+    short: 3Mo
+- id: 4
+  prefix: '4'
+  aliases: []
+  name:
+    long: 4. Mojžíšova
+    medium: 4. Mo.
+    short: 4Mo
+- id: 5
+  prefix: '5'
+  aliases: []
+  name:
+    long: 5. Mojžíšova
+    medium: 5. Mo.
+    short: 5Mo
+- id: 6
+  aliases: []
+  name:
+    long: Jozue
+    medium: Joz.
+    short: Joz
+- id: 7
+  aliases: []
+  name:
+    long: Soudci
+    medium: Sou.
+    short: Sd
+- id: 8
+  aliases: []
+  name:
+    long: Rut
+    medium: Rut
+    short: Rut
+- id: 9
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Samuelova
+    medium: 1. Sa.
+    short: 1Sa
+- id: 10
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Samuelova
+    medium: 2. Sa.
+    short: 2Sa
+- id: 11
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Královská
+    medium: 1. Kr.
+    short: 1Kr
+- id: 12
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Královská
+    medium: 2. Kr.
+    short: 2Kr
+- id: 13
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Paralipomenon
+    medium: 1. Pa.
+    short: 1Pa
+- id: 14
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Paralipomenon
+    medium: 2. Pa.
+    short: 2Pa
+- id: 15
+  aliases: []
+  name:
+    long: Ezra
+    medium: Ezra
+    short: Ezr
+- id: 16
+  aliases: []
+  name:
+    long: Nehemjáš
+    medium: Neh.
+    short: Ne
+- id: 17
+  aliases: []
+  name:
+    long: Ester
+    medium: Est.
+    short: Es
+- id: 18
+  aliases: []
+  name:
+    long: Job
+    medium: Job
+    short: Job
+- id: 19
+  aliases: []
+  name:
+    long: Žalmy
+    medium: Ža.
+    short: Ža
+- id: 20
+  aliases: []
+  name:
+    long: Přísloví
+    medium: Přís.
+    short: Př
+- id: 21
+  aliases: []
+  name:
+    long: Kazatel
+    medium: Kaz.
+    short: Ka
+- id: 22
+  aliases: []
+  name:
+    long: Šalomounova píseň
+    medium: Pís.
+    short: Pís
+- id: 23
+  aliases: []
+  name:
+    long: Izajáš
+    medium: Iz.
+    short: Iz
+- id: 24
+  aliases: []
+  name:
+    long: Jeremjáš
+    medium: Jer.
+    short: Jer
+- id: 25
+  aliases: []
+  name:
+    long: Nářky
+    medium: Nář.
+    short: Ná
+- id: 26
+  aliases: []
+  name:
+    long: Ezekiel
+    medium: Eze.
+    short: Ez
+- id: 27
+  aliases: []
+  name:
+    long: Daniel
+    medium: Dan.
+    short: Da
+- id: 28
+  aliases: []
+  name:
+    long: Ozeáš
+    medium: Oz.
+    short: Oz
+- id: 29
+  aliases: []
+  name:
+    long: Joel
+    medium: Joel
+    short: Joe
+- id: 30
+  aliases: []
+  name:
+    long: Amos
+    medium: Amos
+    short: Am
+- id: 31
+  aliases: []
+  name:
+    long: Obadjáš
+    medium: Obj.
+    short: Ob
+- id: 32
+  aliases: []
+  name:
+    long: Jonáš
+    medium: Jon.
+    short: Jon
+- id: 33
+  aliases: []
+  name:
+    long: Micheáš
+    medium: Mi.
+    short: Mi
+- id: 34
+  aliases: []
+  name:
+    long: Nahum
+    medium: Nah.
+    short: Na
+- id: 35
+  aliases: []
+  name:
+    long: Habakuk
+    medium: Hab.
+    short: Hab
+- id: 36
+  aliases: []
+  name:
+    long: Sefanjáš
+    medium: Sef.
+    short: Sef
+- id: 37
+  aliases: []
+  name:
+    long: Ageus
+    medium: Ag.
+    short: Ag
+- id: 38
+  aliases: []
+  name:
+    long: Zecharjáš
+    medium: Zach.
+    short: Ze
+- id: 39
+  aliases: []
+  name:
+    long: Malachiáš
+    medium: Mal.
+    short: Mal
+- id: 40
+  aliases: []
+  name:
+    long: Matouš
+    medium: Mt.
+    short: Mt
+- id: 41
+  aliases: []
+  name:
+    long: Marek
+    medium: Mr.
+    short: Mr
+- id: 42
+  aliases: []
+  name:
+    long: Lukáš
+    medium: Lk.
+    short: Lk
+- id: 43
+  aliases: []
+  name:
+    long: Jan
+    medium: Jan
+    short: Jan
+- id: 44
+  aliases: []
+  name:
+    long: Skutky
+    medium: Sk.
+    short: Sk
+- id: 45
+  aliases: []
+  name:
+    long: Římanům
+    medium: Řím.
+    short: Ří
+- id: 46
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Korinťanům
+    medium: 1. Ko.
+    short: 1Ko
+- id: 47
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Korinťanům
+    medium: 2. Ko.
+    short: 2Ko
+- id: 48
+  aliases: []
+  name:
+    long: Galaťanům
+    medium: Ga.
+    short: Ga
+- id: 49
+  aliases: []
+  name:
+    long: Efezanům
+    medium: Ef.
+    short: Ef
+- id: 50
+  aliases: []
+  name:
+    long: Filipanům
+    medium: Fil.
+    short: Fil
+- id: 51
+  aliases: []
+  name:
+    long: Kolosanům
+    medium: Kol.
+    short: Kol
+- id: 52
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Tesaloničanům
+    medium: 1. Te.
+    short: 1Te
+- id: 53
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Tesaloničanům
+    medium: 2. Te.
+    short: 2Te
+- id: 54
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Timoteovi
+    medium: 1. Ti.
+    short: 1Ti
+- id: 55
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Timoteovi
+    medium: 2. Ti.
+    short: 2Ti
+- id: 56
+  aliases: []
+  name:
+    long: Titovi
+    medium: Tit.
+    short: Tit
+- id: 57
+  aliases: []
+  name:
+    long: Filemonovi
+    medium: Fm.
+    short: Fm
+- id: 58
+  aliases: []
+  name:
+    long: Hebrejcům
+    medium: Heb.
+    short: Heb
+- id: 59
+  aliases: []
+  name:
+    long: Jakub
+    medium: Jak.
+    short: Jk
+- id: 60
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Petra
+    medium: 1. Pe.
+    short: 1Pe
+- id: 61
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Petra
+    medium: 2. Pe.
+    short: 2Pe
+- id: 62
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1. Jana
+    medium: 1. Ja.
+    short: 1Ja
+- id: 63
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2. Jana
+    medium: 2. Ja.
+    short: 2Ja
+- id: 64
+  prefix: '3'
+  aliases: []
+  name:
+    long: 3. Jana
+    medium: 3. Ja.
+    short: 3Ja
+- id: 65
+  aliases: []
+  name:
+    long: Juda
+    medium: Juda
+    short: Juda
+- id: 66
+  aliases: []
+  name:
+    long: Zjevení
+    medium: Zj.
+    short: Zj

--- a/locale/cs.yaml
+++ b/locale/cs.yaml
@@ -63,6 +63,29 @@ settings:
       description: 'Přizpůsobte formát citace pomocí proměnných: {bibleRef}, {bibleRefLinked}, {quote}'
     preview:
       name: Náhled biblické citace
+  offlineBible:
+    name: Offline Bible
+    description: Naimportujte jednou biblické EPUB a používejte místní data kapitol pro offline vyhledávání citací.
+    enabled:
+      name: Povolit offline Bibli
+      description: Umožní citačnímu procesu používat importovaná místní biblická data.
+    preferOffline:
+      name: Upřednostnit offline citace
+      description: Nejprve zkontroluje importovanou offline Bibli, než se pokusí o online načtení.
+    allowOnlineFallback:
+      name: Povolit online zálohu
+      description: Pokud offline data chybí, plugin se může pokusit použít online poskytovatele citací.
+    status:
+      name: Stav nainstalovaného jazyka
+      notInstalled: Pro jazyk {{language}} není nainstalována žádná offline Bible.
+      installed: Offline Bible pro jazyk {{language}} byla nainstalována ze souboru {{sourceFileName}} dne {{importedAt}} a obsahuje {{chapterCount}} kapitol.
+    actions:
+      name: Akce offline Bible
+      description: Importujte, nahraďte, odstraňte nebo zkontrolujte offline biblický korpus pro vybraný jazyk.
+      import: Importovat biblické EPUB
+      reimport: Znovu importovat biblické EPUB
+      remove: Odstranit offline Bibli
+      openFolder: Otevřít složku offline Bible
 commands:
   linkUnlinkedBibleReferences: Propojit neodkazované biblické reference
   convertToJWLibraryLinks: Převést odkazy ve výběru na JW Library odkazy
@@ -87,6 +110,12 @@ notices:
   noBibleLinkAtCursor: Na pozici kurzoru nebyl nalezen žádný JW Library odkaz
   bibleQuoteAlreadyExists: Biblická citace již existuje
   errorInsertingQuotes: Chyba při vkládání biblických citací
+  bibleQuoteFetchFailed: Biblický text se nepodařilo načíst, zkuste to prosím znovu
+  offlineBibleImported: Offline Bible byla importována pro jazyk {{language}}
+  offlineBibleReimported: Offline Bible byla znovu importována pro jazyk {{language}}
+  offlineBibleRemoved: Offline Bible byla odstraněna pro jazyk {{language}}
+  offlineBibleImportFailed: Import offline biblického EPUB se nezdařil
+  offlineBibleOpenFolderFailed: Nepodařilo se otevřít složku offline Bible
 suggestions:
   createLink: 'Vytvořit odkaz: {{text}}'
   createLinks: 'Vytvořit odkazy: {{text}}'
@@ -101,3 +130,7 @@ errors:
   invalidVerseFormat: Neplatný formát verše
   invalidReferenceFormat: Neplatný formát reference
   unsupportedLanguage: Nepodporovaný jazyk
+  offlineBibleNotInstalled: Pro jazyk {{language}} není nainstalována žádná offline Bible. Pro povolení offline citací naimportujte v nastavení biblické EPUB.
+  offlineBibleVerseMissing: Požadované verše v offline Bibli pro jazyk {{language}} chybí nebo je nelze přečíst.
+  offlineBibleLookupFailed: Vyhledání v offline Bibli se nezdařilo.
+  onlineFallbackDisabled: Online záloha je vypnuta.

--- a/locale/cs.yaml
+++ b/locale/cs.yaml
@@ -1,0 +1,103 @@
+settings:
+  language:
+    name: Jazyk
+    description: Vyberte jazyk pro biblické reference
+  openAutomatically:
+    name: Automaticky otevřít odkaz
+    description: Přesune příkaz "Vytvořit odkaz a otevřít" na vrchol seznamu
+  updatedLinkStructure:
+    name: Zachovat text odkazu
+    description: Pokud je zapnuto, aktuální text odkazu bude zachován při převodu biblického textu
+    keepCurrentStructure: Zachovat aktuální strukturu
+    usePluginSettings: Použít nastavení pluginu
+  noLanguageParameter:
+    name: Vytvářet odkazy bez jazykového parametru
+    description: Pokud je zapnuto, jazykový parametr nebude přidán do odkazu. Odkaz se otevře v jazyce aplikace JW Library
+  reconvertExistingLinks:
+    name: Znovu převést existující odkazy
+    description: Pokud je zapnuto, již převedené jwlibrary:// odkazy budou znovu převedeny podle aktuálního nastavení formátování. Umožňuje aktualizovat všechny odkazy podle nejnovějších preferencí.
+  bookLength:
+    name: Délka textu odkazu
+    description: Vyberte délku textu odkazu
+    short: Krátký
+    medium: Střední
+    long: Dlouhý
+  linkStyling:
+    name: Styl odkazu
+    description: Vyberte znaky nebo emoji pro přidání před, za nebo do odkazu; vyberte styl písma
+    reset: 'Obnovit výchozí: "{{default}}"'
+    prefixOutsideLink:
+      name: Předpona mimo odkaz
+      description: Text přidaný před odkaz
+    prefixInsideLink:
+      name: Předpona uvnitř odkazu
+      description: Text přidaný na začátek textu odkazu
+    suffixInsideLink:
+      name: Přípona uvnitř odkazu
+      description: Text přidaný na konec textu odkazu
+    suffixOutsideLink:
+      name: Přípona mimo odkaz
+      description: Text přidaný za odkaz
+    presets:
+      name: Přednastavené styly
+      description: Vyberte přednastavený styl odkazu
+    fontStyle:
+      name: Styl písma
+      description: Vyberte styl písma pro text odkazu
+      normal: Normální
+      italic: Kurzíva
+      bold: Tučné
+    preview:
+      name: Náhled odkazu
+  bibleQuote:
+    name: Formátování biblické citace
+    description: Nakonfigurujte formátování biblických citací při vkládání
+    presets:
+      name: Přednastavené šablony
+      short: Odkaz + citace
+      plain: Odkaz v citaci
+      foldable: Sbalitelný blok
+      expanded: Rozbalený blok
+    template:
+      name: Šablona citace
+      description: 'Přizpůsobte formát citace pomocí proměnných: {bibleRef}, {bibleRefLinked}, {quote}'
+    preview:
+      name: Náhled biblické citace
+commands:
+  linkUnlinkedBibleReferences: Propojit neodkazované biblické reference
+  convertToJWLibraryLinks: Převést odkazy ve výběru na JW Library odkazy
+  insertBibleQuotes: Vložit biblické citace pro JW Library odkazy
+  insertBibleQuoteAtCursor: Vložit biblickou citaci na pozici kurzoru
+convertSuggester:
+  emptyStateText: Vyberte typ převodu
+  options:
+    all: Vše
+    bible: Biblické reference
+    publication: Publikace
+contextMenu:
+  insertBibleQuote: Vložit biblickou citaci
+notices:
+  convertedBibleReferences: 'Převedeno {{count}} biblických referencí'
+  pleaseSelectText: Prosím vyberte text k převodu
+  noBibleReferencesFound: Nebyly nalezeny žádné biblické reference
+  bibleQuotesInserted: Biblické citace úspěšně vloženy
+  bibleQuotesInsertedSelection: Biblické citace vloženy pro výběr
+  bibleQuoteInsertedAtCursor: Biblická citace vložena na pozici kurzoru
+  noBibleLinksFound: Nebyly nalezeny žádné JW Library odkazy
+  noBibleLinkAtCursor: Na pozici kurzoru nebyl nalezen žádný JW Library odkaz
+  bibleQuoteAlreadyExists: Biblická citace již existuje
+  errorInsertingQuotes: Chyba při vkládání biblických citací
+suggestions:
+  createLink: 'Vytvořit odkaz: {{text}}'
+  createLinks: 'Vytvořit odkazy: {{text}}'
+  createAndOpen: 'Vytvořit odkaz a otevřít: {{text}}'
+  createMultipleAndOpenFirst: 'Vytvořit odkazy a otevřít první: {{text}}'
+  typing: 'Zadejte biblickou referenci: {{text}}'
+  typingEmpty: Zadejte biblickou referenci
+errors:
+  invalidVerseNumber: Neplatné číslo verše
+  versesAscendingOrder: Verše musí být ve vzestupném pořadí
+  chaptersAscendingOrder: Kapitoly musí být ve vzestupném pořadí
+  invalidVerseFormat: Neplatný formát verše
+  invalidReferenceFormat: Neplatný formát reference
+  unsupportedLanguage: Nepodporovaný jazyk

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An Obsidian plugin that helps creating JW Library links",
   "main": "main.js",
   "scripts": {
-    "dev": "DEBUG=true node esbuild.config.mjs",
+    "dev": "cross-env DEBUG=true node esbuild.config.mjs",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "version": "changeset version && node version-bump.mjs",
     "release": "VERSION=$(jq -r '.version' manifest.json) && git tag -a $VERSION -m \"Release $VERSION\" && git push origin $VERSION",
@@ -33,6 +33,7 @@
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",
     "builtin-modules": "^5.1.0",
+    "cross-env": "^10.1.0",
     "esbuild": "^0.28.0",
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       builtin-modules:
         specifier: ^5.1.0
         version: 5.1.0
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
@@ -369,6 +372,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
@@ -1285,6 +1291,11 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3016,6 +3027,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
@@ -3946,6 +3959,11 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   crelt@1.0.6: {}
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/src/__tests__/__helpers__/initializeBibleBooksForTests.ts
+++ b/src/__tests__/__helpers__/initializeBibleBooksForTests.ts
@@ -4,6 +4,7 @@ import { __getCache } from '@/stores/bibleBooks';
 import type { BibleBook, Language } from '@/types';
 import yaml from 'js-yaml';
 import { LANGUAGES } from '@/consts/languages';
+import { getBookLanguage } from '@/utils/signLanguage';
 
 const PROJECT_ROOT = resolve(__dirname, '../../..');
 const LOCALE_DIR = join(PROJECT_ROOT, 'locale');
@@ -16,15 +17,23 @@ export function initializeTestBibleBooks(
   languages: Language[] = Object.keys(LANGUAGES) as Language[],
 ): void {
   const booksCache = __getCache();
+  const loadedBooks = new Map<Language, readonly Omit<BibleBook, 'chapters'>[]>();
 
   languages.forEach((lang) => {
     try {
-      const filePath = join(LOCALE_DIR, 'bibleBooks', `${lang}.yaml`);
-      const content = readFileSync(filePath, 'utf8');
-      const books = yaml.load(content, { schema: yaml.JSON_SCHEMA }) as readonly Omit<
-        BibleBook,
-        'chapters'
-      >[];
+      const sourceLanguage = getBookLanguage(lang);
+      let books = loadedBooks.get(sourceLanguage);
+
+      if (!books) {
+        const filePath = join(LOCALE_DIR, 'bibleBooks', `${sourceLanguage}.yaml`);
+        const content = readFileSync(filePath, 'utf8');
+        books = yaml.load(content, { schema: yaml.JSON_SCHEMA }) as readonly Omit<
+          BibleBook,
+          'chapters'
+        >[];
+        loadedBooks.set(sourceLanguage, books);
+      }
+
       booksCache.set(lang, books);
     } catch (error) {
       console.warn(`Failed to load test data for language ${lang}:`, error);

--- a/src/consts/languages.json
+++ b/src/consts/languages.json
@@ -82,6 +82,15 @@
     "isRTL": false
   },
   {
+    "code": "B",
+    "locale": "cs",
+    "vernacular": "Čeština",
+    "script": "ROMAN",
+    "name": "Czech",
+    "isSignLanguage": false,
+    "isRTL": false
+  },
+  {
     "code": "X",
     "locale": "de",
     "vernacular": "Deutsch",

--- a/src/consts/languagesUnsupported.json
+++ b/src/consts/languagesUnsupported.json
@@ -1800,15 +1800,6 @@
     "isRTL": false
   },
   {
-    "code": "B",
-    "locale": "cs",
-    "vernacular": "čeština",
-    "script": "ROMAN",
-    "name": "Czech",
-    "isSignLanguage": false,
-    "isRTL": false
-  },
-  {
     "code": "CSE",
     "locale": "cse",
     "vernacular": "český znakový jazyk",

--- a/src/services/TranslationService.ts
+++ b/src/services/TranslationService.ts
@@ -227,7 +227,8 @@ export class TranslationService {
       locale === 'pt' ||
       locale === 'fr' ||
       locale === 'hr' ||
-      locale === 'vi'
+      locale === 'vi' ||
+      locale === 'cs'
     );
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 // obsidian language
-export type Locale = 'en' | 'de' | 'fi' | 'es' | 'nl' | 'ko' | 'fr' | 'pt' | 'hr' | 'vi';
+export type Locale = 'en' | 'de' | 'fi' | 'es' | 'nl' | 'ko' | 'fr' | 'pt' | 'hr' | 'vi' | 'cs';
 
 // plugin language
 export type Language =
@@ -13,6 +13,7 @@ export type Language =
   | 'TPO'
   | 'C'
   | 'VT'
+  | 'B'
   // Sign languages
   | 'ASL'
   | 'LSA'


### PR DESCRIPTION
Cherry-picks the accepted parts of #241 onto the current `main` branch.

Included from #241:
- Czech language support
- Windows `pnpm dev` fix via `cross-env`

Not included:
- Locale detection changes

The Windows locale bundle path fix is already on `main`, so this branch keeps that by rebasing/cherry-picking onto the latest base rather than reintroducing it separately.

Thanks again to @RomaCZ for the contribution and especially for the Czech translations.
