### PR TITLE
minor fix: bible fetcher was picking up brazilian portuguese texts instead of portuguese (Portugal)

### DIFF
--- a/.changeset/bible-fetcher-portuguese-fix.md
+++ b/.changeset/bible-fetcher-portuguese-fix.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+Fix Portuguese WOL URL generation for Portuguese (Portugal) so the Bible fetcher uses the correct TPO endpoint.

--- a/src/__tests__/BibleTextFetcher.test.ts
+++ b/src/__tests__/BibleTextFetcher.test.ts
@@ -65,7 +65,7 @@ describe('BibleTextFetcher', () => {
 
     test('builds correct URL for Portuguese', () => {
       expect(BibleTextFetcher.buildWOLUrl(66, 21, 'TPO')).toBe(
-        'https://wol.jw.org/pt_pt/wol/b/r5/lp-t/nwt/66/21',
+        'https://wol.jw.org/pt_pt/wol/b/r296/lp-tpo/nwt/66/21',
       );
     });
 

--- a/src/services/BibleTextFetcher.ts
+++ b/src/services/BibleTextFetcher.ts
@@ -43,7 +43,7 @@ const WOL_LANG_CONFIG: Record<string, WOLLangConfig> = {
   S: { region: 'r4', lp: 'lp-s' },
   F: { region: 'r30', lp: 'lp-f' },
   KO: { region: 'r8', lp: 'lp-ko' },
-  TPO: { region: 'r5', lp: 'lp-t' },
+  TPO: { region: 'r296', lp: 'lp-tpo' },
   C: { region: 'r19', lp: 'lp-c' },
   VT: { region: 'r47', lp: 'lp-vt' },
 };


### PR DESCRIPTION
Fix Portuguese WOL URL generation for Portuguese (Portugal) so the Bible fetcher uses the correct TPO endpoint.