### PR TITLE
feat: add Cibemba (CW) language support

### DIFF
--- a/.changeset/add-cibemba-language-support.md
+++ b/.changeset/add-cibemba-language-support.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': minor
+---
+
+Add support for Cibemba.

--- a/.claude/skills/add-language/languages_by_users.json
+++ b/.claude/skills/add-language/languages_by_users.json
@@ -47,7 +47,8 @@
   {
     "language": "Bemba",
     "users": 123600,
-    "supported": false
+    "supported": true,
+    "languageCode": "CW"
   },
   {
     "language": "Polish",

--- a/LOCALIZATION.md
+++ b/LOCALIZATION.md
@@ -6,6 +6,7 @@
 | ---- | --------------------------------- |
 | B    | čeština / Czech                   |
 | C    | hrvatski / Croatian               |
+| CW   | Cibemba / Cibemba                 |
 | D    | Dansk / Danish                    |
 | E    | English / English                 |
 | F    | français / French                 |

--- a/locale/bem.yaml
+++ b/locale/bem.yaml
@@ -1,0 +1,136 @@
+settings:
+  language:
+    name: Ululimi
+    description: Salapo ululimi ulwa malembo ya Baibolo
+  openAutomatically:
+    name: Isulapo amalinki mu kupanga
+    description: Ipusha icipope ca "Ifumya kabili wisule" pa muulu wa fyonse
+  updatedLinkStructure:
+    name: Sungilila amalembo ya linki
+    description: Nga cabikwa, amalembo yaba muli linki yalisungwa ilyo ulekonkomesha amalembo ya Baibolo
+    keepCurrentStructure: Sunga icimo capali nomba
+    usePluginSettings: Bomfya ifyo wabika muli plugin
+  noLanguageParameter:
+    name: Panga linki ishishipanda pa lulimi
+    description: Nga cabikwa, ululimi tabwakubikwa muli linki. Linki yakeisula mu lulimi ulwaba mu JW Library
+  reconvertExistingLinks:
+    name: Pyangulula amalinki ayalipo
+    description: Nga cabikwa, amalinki ya jwlibrary:// ayalibembulwa kale yakapyangululwa ukulingana ne fyo wabika nomba. Ici cikalengo kuti wonse amalinki yacileelele ifyo waikatilako.
+  bookLength:
+    name: Ubutali bwa malembo ya linki
+    description: Salapo ubutali bwa malembo ya linki
+    short: Akashoso
+    medium: Mu kati
+    long: Akatali
+  linkStyling:
+    name: Ifyo linki yamoneka
+    description: Salapo ifishibilo nelyo emoji ya kubika ilyo ushilatampa linki, mu kati nelyo ku mpela. Salapo ne mfwala ya makalata.
+    reset: 'Bwesesha ku ca cilibatu: "{{default}}"'
+    prefixOutsideLink:
+      name: Ica kutampa kunse kwa linki
+      description: Amalembo ya kubika ilyo ushilatampa linki
+    prefixInsideLink:
+      name: Ica kutampa mu kati ka linki
+      description: Amalembo ya kubika kunkulo ya malembo ya linki
+    suffixInsideLink:
+      name: Ica kupwisha mu kati ka linki
+      description: Amalembo ya kubika ku mpela ya malembo ya linki
+    suffixOutsideLink:
+      name: Ica kupwisha kunse kwa linki
+      description: Amalembo ya kubika pa numa ya linki
+    presets:
+      name: Ifyalipekanishiwa
+      description: Salapo icalipekanishiwa ica linki
+    fontStyle:
+      name: Imfwala ya makalata
+      description: Salapo imfwala ya makalata ya malembo ya linki
+      normal: Iyatampikwa
+      italic: Iyatatatika
+      bold: Iyakosa
+    preview:
+      name: Ukumona linki
+  bibleQuote:
+    name: Ukupwililika amashiwi ya Baibolo
+    description: Pekanya ifyo amashiwi ya Baibolo yakaba ilyo yabikwa
+    presets:
+      name: Ifya kubomfya ifyalipekanishiwa
+      short: Linki + ishiwi
+      plain: Linki muli ishiwi
+      foldable: Akacalo akangapindiwa
+      expanded: Akacalo akafuulwa
+    template:
+      name: Icilangililo ca mashiwi
+      description: 'Bomfya ifishibilo ifi pa kupanga ifyo mashiwi yakaba: {bibleRef}, {bibleRefLinked}, {quote}'
+    preview:
+      name: Ukumona amashiwi ya Baibolo
+  offlineBible:
+    name: Baibolo wa kunse kwa intaneti
+    description: Letapo Baibolo wa EPUB umuku umo lwekela kabili bomfya amasambililo ya pa makompyuta nga taupo intaneti.
+    enabled:
+      name: Suminisha Baibolo wa kunse kwa intaneti
+      description: Suminisha amalembo ukubomfya Baibolo wa kuli kompyuta uo waletele.
+    preferOffline:
+      name: Cabilisha Baibolo wa kunse kwa intaneti
+      description: Tala umona Baibolo wakuli kompyuta pa ntaanshi ya ukufwaya pa intaneti.
+    allowOnlineFallback:
+      name: Suminisha ukufwaya pa intaneti
+      description: Nga Baibolo wakuli kompyuta tabaliko, plugin ikafwaye pa intaneti.
+    installedList:
+      name: BaiBolo ba kunse kwa intaneti abaletwa
+      description: Baibolo umo wene fye e wingaba pa ululimi. Ululimi lulipusukila mu lyashi lya EPUB.
+      empty: Tapali Baibolo wa kunse kwa intaneti uwaletwa.
+      entry: '{{sourceFileName}} — {{chapterCount}} ifipandwa, waletwa {{importedAt}}'
+    actions:
+      name: Ifyakucita pali Baibolo wa kunse kwa intaneti
+      description: Letapo EPUB pa kulundako ululimi ulupya. Pa kupyangulula uwalipo, tala umufumyepo.
+      import: Letapo Baibolo wa EPUB
+      importing: Ukuleta...
+      openFolder: Isula apo Baibolo wa kunse kwa intaneti aba
+commands:
+  linkUnlinkedBibleReferences: Lundako amalinki kuli amalembo ya Baibolo ayashili na malinki
+  convertToJWLibraryLinks: Pyangulula amalinki yasalwa ku malinki ya JW Library
+  insertBibleQuotes: Bikapo amashiwi ya Baibolo pa malinki ya JW Library
+  insertBibleQuoteAtCursor: Bikapo amashiwi ya Baibolo apo kasanika nshiba
+convertSuggester:
+  emptyStateText: Salapo umusango wa kupyangulula
+  options:
+    all: Fyonse
+    bible: Amalembo ya Baibolo
+    publication: Impapulo
+contextMenu:
+  insertBibleQuote: Bikapo amashiwi ya Baibolo
+notices:
+  convertedBibleReferences: 'Wapyangulula amalembo ya Baibolo {{count}}'
+  pleaseSelectText: Mukwai salapo amalembo ya kupyangulula
+  noBibleReferencesFound: Tapasangwa amalembo ya Baibolo
+  bibleQuotesInserted: Amashiwi ya Baibolo yabikwa bwino
+  bibleQuotesInsertedSelection: Amashiwi ya Baibolo yabikwa pa cisalwa
+  bibleQuoteInsertedAtCursor: Amashiwi ya Baibolo yabikwa apo kasanika nshiba
+  noBibleLinksFound: Tapasangwa amalinki ya JW Library
+  noBibleLinkAtCursor: Apo kasanika nshiba tapasangwa linki ya JW Library
+  bibleQuoteAlreadyExists: Amashiwi ya Baibolo nayalibapo kale
+  errorInsertingQuotes: Kwacitika ubulufyanya pa kubika amashiwi ya Baibolo
+  bibleQuoteFetchFailed: Te kufwaya amashiwi ya Baibolo — mukwai eseni cipya
+  offlineBibleImported: 'Baibolo wa kunse kwa intaneti waletwa wa {{language}}'
+  offlineBibleRemoved: 'Baibolo wa kunse kwa intaneti wafumishiwa wa {{language}}'
+  offlineBibleAlreadyInstalled: 'Baibolo wa kunse kwa intaneti uwa {{language}} naulipo kale. Mufumyepo intaanshi ya kuleta nakabili.'
+  offlineBibleImportFailed: Califilwa ukuleta Baibolo wa EPUB wa kunse kwa intaneti
+  offlineBibleOpenFolderFailed: Te kwisula ifaila ya Baibolo wa kunse kwa intaneti
+suggestions:
+  createLink: 'Panga linki: {{text}}'
+  createLinks: 'Panga amalinki: {{text}}'
+  createAndOpen: 'Panga linki kabili isula: {{text}}'
+  createMultipleAndOpenFirst: 'Panga amalinki kabili isula uwa kubalilapo: {{text}}'
+  typing: 'Lemba lembo lya Baibolo: {{text}}'
+  typingEmpty: Lemba lembo lya Baibolo
+errors:
+  invalidVerseNumber: Inomba ya cikomo tayalingwa
+  versesAscendingOrder: Ifikomo fifwile ukuba mu butantiko bwa ku muulu
+  chaptersAscendingOrder: Ifipandwa fifwile ukuba mu butantiko bwa ku muulu
+  invalidVerseFormat: Imimoneke ya cikomo tayalingwa
+  invalidReferenceFormat: Imimoneke ya lembo tayalingwa
+  unsupportedLanguage: Ululimi tabwasuminishiwa
+  offlineBibleNotInstalled: 'Tapali Baibolo wa kunse kwa intaneti uwa {{language}}. Letapo Baibolo wa EPUB mu settings pa kusuminisha amashiwi ya kunse kwa intaneti.'
+  offlineBibleVerseMissing: 'Ifikomo fyalombwa tafyabako nelyo te kufibelenga mu Baibolo wa kunse kwa intaneti uwa {{language}}.'
+  offlineBibleLookupFailed: Ukufwaya muli Baibolo wa kunse kwa intaneti kwalifilwa.
+  onlineFallbackDisabled: Ukufwaya pa intaneti kwaeshiwa.

--- a/locale/bibleBooks/CW.yaml
+++ b/locale/bibleBooks/CW.yaml
@@ -1,0 +1,413 @@
+- id: 1
+  aliases: []
+  name:
+    long: Ukutendeka
+    medium: Ukute.
+    short: Ukt
+- id: 2
+  aliases: []
+  name:
+    long: Ukufuma
+    medium: Ukufu.
+    short: Ukf
+- id: 3
+  aliases: []
+  name:
+    long: Ubwina Lebi
+    medium: Lebi
+    short: Le
+- id: 4
+  aliases: []
+  name:
+    long: Impendwa
+    medium: Impe.
+    short: Imp
+- id: 5
+  aliases: []
+  name:
+    long: Amalango
+    medium: Amala.
+    short: Amg
+- id: 6
+  aliases: []
+  name:
+    long: Yoshua
+    medium: Yosh.
+    short: Yos
+- id: 7
+  aliases: []
+  name:
+    long: Abapingushi
+    medium: Abapi.
+    short: Aba
+- id: 8
+  aliases: []
+  name:
+    long: Ruti
+    medium: Ruti
+    short: Ru
+- id: 9
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1 Samwele
+    medium: 1 Sam.
+    short: 1Sa
+- id: 10
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2 Samwele
+    medium: 2 Sam.
+    short: 2Sa
+- id: 11
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1 Ishamfumu
+    medium: 1 Isha.
+    short: 1Is
+- id: 12
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2 Ishamfumu
+    medium: 2 Isha.
+    short: 2Is
+- id: 13
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1 Imilandu
+    medium: 1 Imila.
+    short: 1Im
+- id: 14
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2 Imilandu
+    medium: 2 Imila.
+    short: 2Im
+- id: 15
+  aliases: []
+  name:
+    long: Esra
+    medium: Esra
+    short: Esr
+- id: 16
+  aliases: []
+  name:
+    long: Nehemia
+    medium: Nehe.
+    short: Neh
+- id: 17
+  aliases: []
+  name:
+    long: Estere
+    medium: Este.
+    short: Est
+- id: 18
+  aliases: []
+  name:
+    long: Yobo
+    medium: Yobo
+    short: Yb
+- id: 19
+  aliases: []
+  name:
+    long: Amalumbo
+    medium: Ilumbo
+    short: Am
+- id: 20
+  aliases: []
+  name:
+    long: Amapinda
+    medium: Amapi.
+    short: Amp
+- id: 21
+  aliases: []
+  name:
+    long: Lukala Milandu
+    medium: Luk. Mil
+    short: Lik. Mil
+- id: 22
+  aliases: []
+  name:
+    long: Ulwimbo lwa Nyimbo
+    medium: Ulwimbo
+    short: Uln
+- id: 23
+  aliases: []
+  name:
+    long: Esaya
+    medium: Esa.
+    short: Es
+- id: 24
+  aliases: []
+  name:
+    long: Yeremia
+    medium: Yer.
+    short: Ye
+- id: 25
+  aliases: []
+  name:
+    long: Inyimbo sha Bulanda
+    medium: Inyimbo
+    short: Isb
+- id: 26
+  aliases: []
+  name:
+    long: Esekiele
+    medium: Esek.
+    short: Ek
+- id: 27
+  aliases: []
+  name:
+    long: Daniele
+    medium: Dan.
+    short: Da
+- id: 28
+  aliases: []
+  name:
+    long: Hosea
+    medium: Hos.
+    short: Ho
+- id: 29
+  aliases: []
+  name:
+    long: Yoele
+    medium: Yoele
+    short: Yoe
+- id: 30
+  aliases: []
+  name:
+    long: Amose
+    medium: Amose
+    short: Ams
+- id: 31
+  aliases: []
+  name:
+    long: Obadia
+    medium: Obad.
+    short: Ob
+- id: 32
+  aliases: []
+  name:
+    long: Yona
+    medium: Yona
+    short: Yn
+- id: 33
+  aliases: []
+  name:
+    long: Mika
+    medium: Mika
+    short: Mk
+- id: 34
+  aliases: []
+  name:
+    long: Nahumu
+    medium: Nahu.
+    short: Na
+- id: 35
+  aliases: []
+  name:
+    long: Habakuki
+    medium: Haba.
+    short: Hab
+- id: 36
+  aliases: []
+  name:
+    long: Sefania
+    medium: Sefa.
+    short: Sef
+- id: 37
+  aliases: []
+  name:
+    long: Hagai
+    medium: Hag.
+    short: Hg
+- id: 38
+  aliases: []
+  name:
+    long: Sekaria
+    medium: Seka.
+    short: Sek
+- id: 39
+  aliases: []
+  name:
+    long: Malaki
+    medium: Mal.
+    short: Mal
+- id: 40
+  aliases: []
+  name:
+    long: Mateo
+    medium: Mat.
+    short: Mt
+- id: 41
+  aliases: []
+  name:
+    long: Marko
+    medium: Marko
+    short: Mko
+- id: 42
+  aliases: []
+  name:
+    long: Luka
+    medium: Luka
+    short: Lk
+- id: 43
+  aliases: []
+  name:
+    long: Yohane
+    medium: Yoh.
+    short: Yh
+- id: 44
+  aliases: []
+  name:
+    long: Imilimo
+    medium: Imil.
+    short: Imi
+- id: 45
+  aliases: []
+  name:
+    long: Abena Roma
+    medium: Rom.
+    short: Ro
+- id: 46
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1 Abena Korinti
+    medium: 1 Kor.
+    short: 1Ko
+- id: 47
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2 Abena Korinti
+    medium: 2Ko.
+    short: 2Ko
+- id: 48
+  aliases: []
+  name:
+    long: Abena Galatia
+    medium: Gal.
+    short: Ga
+- id: 49
+  aliases: []
+  name:
+    long: Abena Efese
+    medium: Efes.
+    short: Ef
+- id: 50
+  aliases: []
+  name:
+    long: Abena Filipi
+    medium: Flp.
+    short: Flp
+- id: 51
+  aliases: []
+  name:
+    long: Abena Kolose
+    medium: Kol.
+    short: Ko
+- id: 52
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1 Abena Tesalonika
+    medium: 1 Tes.
+    short: 1Te
+- id: 53
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2 Abena Tesalonika
+    medium: 2 Tes.
+    short: 2Te
+- id: 54
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1 Timote
+    medium: 1 Tim.
+    short: 1Ti
+- id: 55
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2 Timote
+    medium: 2 Tim.
+    short: 2Ti
+- id: 56
+  aliases: []
+  name:
+    long: Tito
+    medium: Tt.
+    short: Tt
+- id: 57
+  aliases: []
+  name:
+    long: Filemone
+    medium: File.
+    short: Flm
+- id: 58
+  aliases: []
+  name:
+    long: AbaHebere
+    medium: Heb.
+    short: He
+- id: 59
+  aliases: []
+  name:
+    long: Yakobo
+    medium: Yako.
+    short: Yak
+- id: 60
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1 Petro
+    medium: 1 Pet.
+    short: 1Pe
+- id: 61
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2 Petro
+    medium: 2 Pet.
+    short: 2Pe
+- id: 62
+  prefix: '1'
+  aliases: []
+  name:
+    long: 1 Yohane
+    medium: 1 Yoh.
+    short: 1Yo
+- id: 63
+  prefix: '2'
+  aliases: []
+  name:
+    long: 2 Yohane
+    medium: 2 Yoh.
+    short: 2Yo
+- id: 64
+  prefix: '3'
+  aliases: []
+  name:
+    long: 3 Yohane
+    medium: 3 Yoh.
+    short: 3Yo
+- id: 65
+  aliases: []
+  name:
+    long: Yuda
+    medium: Yuda
+    short: Yu
+- id: 66
+  aliases: []
+  name:
+    long: Ukusokolola
+    medium: Ukus.
+    short: Uks

--- a/src/consts/languages.json
+++ b/src/consts/languages.json
@@ -466,5 +466,14 @@
     "name": "Italian",
     "isSignLanguage": false,
     "isRTL": false
+  },
+  {
+    "code": "CW",
+    "locale": "bem",
+    "vernacular": "Cibemba",
+    "script": "ROMAN",
+    "name": "Cibemba",
+    "isSignLanguage": false,
+    "isRTL": false
   }
 ]

--- a/src/consts/languages.ts
+++ b/src/consts/languages.ts
@@ -3,6 +3,7 @@ import languageJson from '@/consts/languages.json';
 
 // obsidian language
 export const LOCALES = [
+  'bem',
   'cs',
   'da',
   'de',
@@ -22,6 +23,7 @@ export const LOCALES = [
 export const LANGUAGE_CODES = [
   'B',
   'C',
+  'CW',
   'D',
   'E',
   'F',

--- a/src/consts/languagesUnsupported.json
+++ b/src/consts/languagesUnsupported.json
@@ -1656,15 +1656,6 @@
     "isRTL": false
   },
   {
-    "code": "CW",
-    "locale": "bem",
-    "vernacular": "Cibemba",
-    "script": "ROMAN",
-    "name": "Cibemba",
-    "isSignLanguage": false,
-    "isRTL": false
-  },
-  {
     "code": "NM",
     "locale": "mwn",
     "vernacular": "Cinamwanga",


### PR DESCRIPTION
## Summary
- Add Cibemba (CW, locale `bem`) to supported languages
- Fetch Bible book names from jw.org → `locale/bibleBooks/CW.yaml`
- Translate UI strings → `locale/bem.yaml`
- Wire `LANGUAGE_CODES`, `LOCALES`, `LOCALIZATION.md`, changeset