### PR TITLE
fix: avoid direct Node fs access in offline Bible folder open

### DIFF
--- a/.changeset/avoid-direct-fs-access.md
+++ b/.changeset/avoid-direct-fs-access.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+Stop using Node's `fs` and `path` modules directly. The offline Bible folder is now created via Obsidian's vault adapter API, addressing the community plugin review warning about direct filesystem access.

--- a/src/services/PluginDataPathService.ts
+++ b/src/services/PluginDataPathService.ts
@@ -1,13 +1,4 @@
-import { FileSystemAdapter, Platform, type App } from 'obsidian';
-
-function joinPath(...segments: string[]): string {
-  if (!Platform.isDesktop) {
-    throw new Error('Node.js APIs are not available on mobile');
-  }
-  // eslint-disable-next-line @typescript-eslint/no-require-imports -- dynamic require for desktop-only Node.js API
-  const { join } = require('path') as typeof import('path');
-  return join(...segments);
-}
+import { FileSystemAdapter, type App } from 'obsidian';
 
 export function getOfflineBibleVaultPath(app: App, pluginId: string): string {
   return `${app.vault.configDir}/plugins/${pluginId}/offline-bible`;
@@ -18,5 +9,5 @@ export function getOfflineBibleAbsolutePath(app: App, pluginId: string): string 
   if (!(adapter instanceof FileSystemAdapter)) {
     throw new Error('Absolute path is only available on the desktop file system adapter.');
   }
-  return joinPath(adapter.getBasePath(), getOfflineBibleVaultPath(app, pluginId));
+  return `${adapter.getBasePath()}/${getOfflineBibleVaultPath(app, pluginId)}`;
 }

--- a/src/settings/sections/linkStyling.ts
+++ b/src/settings/sections/linkStyling.ts
@@ -269,8 +269,6 @@ export function updateLinkStylingPreview(tab: SettingsTabContext): void {
       convertBibleTextToMarkdownLink(reference, tab.plugin.settings),
     );
 
-    console.log(markdownLinks, tab.plugin.settings);
-
     if (!markdownLinks.every(Boolean)) {
       throw new Error('Failed to generate one or more markdown links');
     }

--- a/src/settings/sections/offlineBible.ts
+++ b/src/settings/sections/offlineBible.ts
@@ -1,6 +1,9 @@
 import { Notice, Platform, Setting } from 'obsidian';
 import type { Language } from '@/types';
-import { getOfflineBibleAbsolutePath } from '@/services/PluginDataPathService';
+import {
+  getOfflineBibleAbsolutePath,
+  getOfflineBibleVaultPath,
+} from '@/services/PluginDataPathService';
 import { logger } from '@/utils/logger';
 import { LANGUAGE_LABELS } from '@/consts/languages';
 import type { SettingsTabContext } from '@/settings/types';
@@ -193,10 +196,11 @@ async function handleBibleRemoval(
 
 async function openOfflineBibleFolder(tab: SettingsTabContext): Promise<void> {
   if (!Platform.isDesktop) return;
+  const vaultPath = getOfflineBibleVaultPath(tab.app, tab.plugin.manifest.id);
+  if (!(await tab.app.vault.adapter.exists(vaultPath))) {
+    await tab.app.vault.adapter.mkdir(vaultPath);
+  }
   const folderPath = getOfflineBibleAbsolutePath(tab.app, tab.plugin.manifest.id);
-  // eslint-disable-next-line @typescript-eslint/no-require-imports -- dynamic require for desktop-only Node.js API
-  const { mkdir } = require('fs/promises') as typeof import('fs/promises');
-  await mkdir(folderPath, { recursive: true });
   // eslint-disable-next-line @typescript-eslint/no-require-imports -- dynamic require for desktop-only Electron API
   const { shell } = require('electron') as typeof import('electron');
   const error = await shell.openPath(folderPath);


### PR DESCRIPTION
Use the Obsidian vault adapter (mkdir/exists) instead of fs/promises and drop the path.join require in favor of string concatenation. Addresses the community plugin review warning about direct filesystem access.