### PR TITLE
chore: skip pre-push tests on branch-deletion pushes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm exec lint-staged",
-    "pre-push": "pnpm test:affected"
+    "pre-push": "sh scripts/pre-push.sh"
   },
   "lint-staged": {
     "*.{ts,js,mjs,cjs}": "eslint --fix",

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# pre-push hook body (invoked via simple-git-hooks).
+#
+# Git feeds one line per ref on stdin: "<local_ref> <local_sha> <remote_ref> <remote_sha>".
+# A branch deletion (`git push origin :branch`) has an all-zero <local_sha>, so there is
+# nothing new to test — skip the suite in that case. Run the tests only when at least one
+# ref actually pushes commits.
+
+has_update=0
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+    case "$local_sha" in
+        *[!0]*) has_update=1 ;; # any non-zero char => real update, not a deletion
+    esac
+done
+
+if [ "$has_update" = "0" ]; then
+    echo "[pre-push] Only branch deletions detected — skipping tests."
+    exit 0
+fi
+
+pnpm test:affected


### PR DESCRIPTION
The pre-push hook ran the full test:affected suite on every push, including `git push origin :branch` deletions where nothing new is pushed. Move the hook body into scripts/pre-push.sh, which inspects git's per-ref stdin and skips the suite when all refs are deletions (all-zero local sha).