### PR TITLE
fix: append Bible quote below line when link is embedded in text

### DIFF
--- a/.changeset/fix-quote-replaces-paragraph.md
+++ b/.changeset/fix-quote-replaces-paragraph.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+Fixed Bible quote insertion destroying surrounding text when the link is embedded in a paragraph. The quote is now appended below the line instead of replacing it.

--- a/src/__tests__/insertBibleQuotes.test.ts
+++ b/src/__tests__/insertBibleQuotes.test.ts
@@ -243,6 +243,46 @@ describe('insertAllBibleQuotes', () => {
     expect(mockTransaction).not.toHaveBeenCalled();
   });
 
+  test('should append quote below when link is embedded in surrounding text', async () => {
+    const lineText =
+      'Jehova befähigt uns ([Jer. 1:8-9](jwlibrary:///finder?bible=24001008-24001009&wtlocale=X); w10 15. 1. 9)';
+    mockLastLine.mockReturnValue(0);
+    mockGetLine.mockReturnValue(lineText);
+
+    (findJWLibraryLinks as jest.Mock).mockReturnValue([
+      {
+        url: 'jwlibrary:///finder?bible=24001008-24001009&wtlocale=X',
+        reference: { book: 24, chapter: 1, verseRanges: [{ start: 8, end: 9 }] },
+        lineNumber: 0,
+        lineText,
+      },
+    ]);
+
+    (BibleTextFetcher.fetchBibleText as jest.Mock).mockResolvedValue({
+      success: true,
+      text: 'Have no fear because of their appearance.',
+    });
+
+    (convertBibleTextToMarkdownLink as jest.Mock).mockReturnValue(
+      '[Jer. 1:8-9](jwlibrary:///finder?bible=24001008-24001009&wtlocale=X)',
+    );
+
+    const result = await insertAllBibleQuotes(mockEditor, settings, provider);
+
+    expect(result.inserted).toBe(1);
+    expect(mockTransaction).toHaveBeenCalledWith({
+      changes: [
+        {
+          from: { line: 0, ch: lineText.length },
+          to: { line: 0, ch: lineText.length },
+          text:
+            '\n\n[Jer. 1:8-9](jwlibrary:///finder?bible=24001008-24001009&wtlocale=X)\n' +
+            '> Have no fear because of their appearance.',
+        },
+      ],
+    });
+  });
+
   test('should trim whitespace from variables in custom template', async () => {
     // Test for bug where trailing whitespace breaks markdown formatting
     settings.bibleQuote.template = '> ***{bibleRefLinked}***\n> *{quote}*';
@@ -381,11 +421,11 @@ describe('insertBibleQuoteAtCursor', () => {
     expect(mockTransaction).not.toHaveBeenCalled();
   });
 
-  test('should insert quotes for all links on the same line', async () => {
+  test('should insert quotes for all links on the same line when standalone', async () => {
     mockGetCursor.mockReturnValue({ line: 0, ch: 10 });
     mockLastLine.mockReturnValue(0);
     mockGetLine.mockReturnValue(
-      'jwlibrary:///finder?bible=43003016 and jwlibrary:///finder?bible=40005003',
+      'jwlibrary:///finder?bible=43003016 jwlibrary:///finder?bible=40005003',
     );
 
     (BibleTextFetcher.fetchBibleText as jest.Mock)
@@ -411,13 +451,90 @@ describe('insertBibleQuoteAtCursor', () => {
           from: { line: 0, ch: 0 },
           to: {
             line: 0,
-            ch: 'jwlibrary:///finder?bible=43003016 and jwlibrary:///finder?bible=40005003'.length,
+            ch: 'jwlibrary:///finder?bible=43003016 jwlibrary:///finder?bible=40005003'.length,
           },
           text:
             '[John 3:16](jwlibrary:///finder?bible=43003016&wtlocale=E)\n' +
             '> For God loved the world so much that he gave his only-begotten Son.\n\n' +
             '[Matt. 5:3](jwlibrary:///finder?bible=40005003&wtlocale=E)\n' +
             '> Happy are those conscious of their spiritual need.',
+        },
+      ],
+    });
+  });
+
+  test('should append quote below when link is embedded in surrounding text', async () => {
+    const lineText =
+      'Jehova befähigt uns ([Jer. 1:8-9](jwlibrary:///finder?bible=24001008-24001009&wtlocale=X); w10 15. 1. 9 Abs. 7-8)';
+    mockGetCursor.mockReturnValue({ line: 0, ch: 25 });
+    mockLastLine.mockReturnValue(0);
+    mockGetLine.mockReturnValue(lineText);
+
+    (BibleTextFetcher.fetchBibleText as jest.Mock).mockResolvedValueOnce({
+      success: true,
+      text: 'Have no fear because of their appearance, for I am with you to save you.',
+    });
+
+    (convertBibleTextToMarkdownLink as jest.Mock).mockReturnValueOnce(
+      '[Jer. 1:8-9](jwlibrary:///finder?bible=24001008-24001009&wtlocale=X)',
+    );
+
+    const result = await insertBibleQuoteAtCursor(mockEditor, settings, provider);
+
+    expect(result).toEqual({ inserted: true, alreadyExists: false, fetchFailed: false });
+    expect(mockTransaction).toHaveBeenCalledWith({
+      changes: [
+        {
+          from: { line: 0, ch: lineText.length },
+          to: { line: 0, ch: lineText.length },
+          text:
+            '\n\n[Jer. 1:8-9](jwlibrary:///finder?bible=24001008-24001009&wtlocale=X)\n' +
+            '> Have no fear because of their appearance, for I am with you to save you.',
+        },
+      ],
+    });
+  });
+
+  test('should replace line when link is the only content (standalone)', async () => {
+    const lineText = '[John 3:16](jwlibrary:///finder?bible=43003016&wtlocale=E)';
+    mockGetCursor.mockReturnValue({ line: 0, ch: 10 });
+    mockLastLine.mockReturnValue(0);
+    mockGetLine.mockReturnValue(lineText);
+
+    const result = await insertBibleQuoteAtCursor(mockEditor, settings, provider);
+
+    expect(result).toEqual({ inserted: true, alreadyExists: false, fetchFailed: false });
+    expect(mockTransaction).toHaveBeenCalledWith({
+      changes: [
+        {
+          from: { line: 0, ch: 0 },
+          to: { line: 0, ch: lineText.length },
+          text:
+            '[John 3:16](jwlibrary:///finder?bible=43003016&wtlocale=E)\n' +
+            '> For God loved the world so much that he gave his only-begotten Son.',
+        },
+      ],
+    });
+  });
+
+  test('should append quote below when link has prefix text', async () => {
+    const lineText =
+      'See this reference: [John 3:16](jwlibrary:///finder?bible=43003016&wtlocale=E)';
+    mockGetCursor.mockReturnValue({ line: 0, ch: 25 });
+    mockLastLine.mockReturnValue(0);
+    mockGetLine.mockReturnValue(lineText);
+
+    const result = await insertBibleQuoteAtCursor(mockEditor, settings, provider);
+
+    expect(result).toEqual({ inserted: true, alreadyExists: false, fetchFailed: false });
+    expect(mockTransaction).toHaveBeenCalledWith({
+      changes: [
+        {
+          from: { line: 0, ch: lineText.length },
+          to: { line: 0, ch: lineText.length },
+          text:
+            '\n\n[John 3:16](jwlibrary:///finder?bible=43003016&wtlocale=E)\n' +
+            '> For God loved the world so much that he gave his only-begotten Son.',
         },
       ],
     });

--- a/src/utils/insertBibleQuotes.ts
+++ b/src/utils/insertBibleQuotes.ts
@@ -12,6 +12,17 @@ import {
 import { logger } from '@/utils/logger';
 import { getBookLanguage } from './signLanguage';
 
+const MARKDOWN_LINK_WITH_JWLIBRARY =
+  /\[[^\]]*\]\(jwlibrary:\/\/\/finder\?bible=\d{8}(?:-\d{8})?(?:&[^)]*?)?\)/g;
+const BARE_JWLIBRARY_LINK = /jwlibrary:\/\/\/finder\?bible=\d{8}(?:-\d{8})?(?:&[^\s)]*)?/g;
+
+function isLinkStandaloneOnLine(lineText: string): boolean {
+  const stripped = lineText
+    .replace(MARKDOWN_LINK_WITH_JWLIBRARY, '')
+    .replace(BARE_JWLIBRARY_LINK, '');
+  return stripped.trim().length === 0;
+}
+
 function processTemplate(
   template: string,
   variables: {
@@ -144,11 +155,19 @@ export async function insertAllBibleQuotes(
     try {
       const quoteText = await generateBibleQuoteText(linkInfo, settings, provider);
       if (quoteText) {
-        changes.push({
-          from: { line: linkInfo.lineNumber, ch: 0 },
-          to: { line: linkInfo.lineNumber, ch: currentLine.length },
-          text: quoteText,
-        });
+        if (isLinkStandaloneOnLine(currentLine)) {
+          changes.push({
+            from: { line: linkInfo.lineNumber, ch: 0 },
+            to: { line: linkInfo.lineNumber, ch: currentLine.length },
+            text: quoteText,
+          });
+        } else {
+          changes.push({
+            from: { line: linkInfo.lineNumber, ch: currentLine.length },
+            to: { line: linkInfo.lineNumber, ch: currentLine.length },
+            text: '\n\n' + quoteText,
+          });
+        }
       } else {
         fetchFailed++;
         logger.warn(
@@ -249,15 +268,27 @@ export async function insertBibleQuoteAtCursor(
 
   if (quoteTexts.length > 0) {
     const combinedText = quoteTexts.join('\n\n');
-    editor.transaction({
-      changes: [
-        {
-          from: { line: targetLineNumber, ch: 0 },
-          to: { line: targetLineNumber, ch: targetLineText.length },
-          text: combinedText,
-        },
-      ],
-    });
+    if (isLinkStandaloneOnLine(targetLineText)) {
+      editor.transaction({
+        changes: [
+          {
+            from: { line: targetLineNumber, ch: 0 },
+            to: { line: targetLineNumber, ch: targetLineText.length },
+            text: combinedText,
+          },
+        ],
+      });
+    } else {
+      editor.transaction({
+        changes: [
+          {
+            from: { line: targetLineNumber, ch: targetLineText.length },
+            to: { line: targetLineNumber, ch: targetLineText.length },
+            text: '\n\n' + combinedText,
+          },
+        ],
+      });
+    }
     return { inserted: true, alreadyExists: false, fetchFailed: false };
   }
 


### PR DESCRIPTION
## Summary

- Fixed "Insert Bible quote at cursor" destroying surrounding text when the link is part of a larger paragraph
- Now detects whether the link is standalone on its line; if other text exists, the quote is appended below instead of replacing the line
- Applies to both `insertBibleQuoteAtCursor` and `insertAllBibleQuotes`

Closes #303

## Test plan

- [x] Added test: link embedded in surrounding text → quote appended below
- [x] Added test: link with prefix text → quote appended below
- [x] Added test: standalone link → line replaced as before (existing behavior)
- [x] All 505 tests pass
- [x] Manual test in Obsidian with the reproduction case from #303