### PR TITLE
fix: apply prefix/suffix styling to multi-range links

### DIFF
--- a/.changeset/fix-multi-range-styling.md
+++ b/.changeset/fix-multi-range-styling.md
@@ -1,0 +1,5 @@
+---
+'jw-library-linker': patch
+---
+
+Fix prefix/suffix styling not applied to multi-range links when "Keep current structure" is set.

--- a/src/__tests__/convertBibleTextToMarkdownLink.test.ts
+++ b/src/__tests__/convertBibleTextToMarkdownLink.test.ts
@@ -223,6 +223,96 @@ describe('convertBibleTextToMarkdownLink', () => {
     });
   });
 
+  describe('with prefix/suffix styling on multi-range links', () => {
+    test('applies styling when keepCurrentStructure and no originalText (new link creation)', () => {
+      expect(
+        convertBibleTextToMarkdownLink(
+          {
+            book: 19,
+            chapter: 119,
+            verseRanges: [
+              { start: 1, end: 1 },
+              { start: 5, end: 8 },
+              { start: 50, end: 50 },
+            ],
+          },
+          createSettings({
+            bookLength: 'long',
+            language: 'X',
+            updatedLinkStructure: 'keepCurrentStructure',
+            prefixOutsideLink: '(',
+            prefixInsideLink: '',
+            suffixInsideLink: '',
+            suffixOutsideLink: ')',
+          }),
+        ),
+      ).toBe(
+        '([Psalm 119:1](jwlibrary:///finder?bible=19119001&wtlocale=X),' +
+          '[5-8](jwlibrary:///finder?bible=19119005-19119008&wtlocale=X),' +
+          '[50](jwlibrary:///finder?bible=19119050&wtlocale=X))',
+      );
+    });
+
+    test('applies inside prefix/suffix styling on multi-range links', () => {
+      expect(
+        convertBibleTextToMarkdownLink(
+          {
+            book: 19,
+            chapter: 119,
+            verseRanges: [
+              { start: 1, end: 1 },
+              { start: 5, end: 8 },
+              { start: 50, end: 50 },
+            ],
+          },
+          createSettings({
+            bookLength: 'long',
+            language: 'X',
+            updatedLinkStructure: 'keepCurrentStructure',
+            prefixOutsideLink: '',
+            prefixInsideLink: '📖 ',
+            suffixInsideLink: ' ✓',
+            suffixOutsideLink: '',
+          }),
+        ),
+      ).toBe(
+        '[📖 Psalm 119:1](jwlibrary:///finder?bible=19119001&wtlocale=X),' +
+          '[5-8](jwlibrary:///finder?bible=19119005-19119008&wtlocale=X),' +
+          '[50 ✓](jwlibrary:///finder?bible=19119050&wtlocale=X)',
+      );
+    });
+
+    test('skips styling when keepCurrentStructure and originalText is provided', () => {
+      expect(
+        convertBibleTextToMarkdownLink(
+          {
+            book: 19,
+            chapter: 119,
+            verseRanges: [
+              { start: 1, end: 1 },
+              { start: 5, end: 8 },
+              { start: 50, end: 50 },
+            ],
+          },
+          createSettings({
+            bookLength: 'long',
+            language: 'X',
+            updatedLinkStructure: 'keepCurrentStructure',
+            prefixOutsideLink: '(',
+            prefixInsideLink: '',
+            suffixInsideLink: '',
+            suffixOutsideLink: ')',
+          }),
+          'Psalm 119:1,5-8,50',
+        ),
+      ).toBe(
+        '[Psalm 119:1](jwlibrary:///finder?bible=19119001&wtlocale=X),' +
+          '[5-8](jwlibrary:///finder?bible=19119005-19119008&wtlocale=X),' +
+          '[50](jwlibrary:///finder?bible=19119050&wtlocale=X)',
+      );
+    });
+  });
+
   test('throws error on invalid reference', () => {
     expect(() =>
       convertBibleTextToMarkdownLink(

--- a/src/utils/convertBibleTextToMarkdownLink.ts
+++ b/src/utils/convertBibleTextToMarkdownLink.ts
@@ -63,20 +63,22 @@ export function convertBibleTextToMarkdownLink(
       start === end ? start.toString() : `${start}-${end}`,
     );
 
+    const skipStyling = keepStrukture && !!originalText;
+
     // Create array of markdown links
     const styledLinks = verseRanges
       .map((range, i) => {
         let linkText;
         if (i === 0) {
           // First link includes book name and chapter
-          if (keepStrukture) {
+          if (skipStyling) {
             linkText = `${bookName} ${reference.chapter}:${range}`;
           } else {
             linkText = `${prefixInside}${bookName} ${reference.chapter}:${range}`;
           }
         } else if (i === verseRanges.length - 1) {
           // Last link includes verse numbers and suffix
-          if (keepStrukture) {
+          if (skipStyling) {
             linkText = range;
           } else {
             linkText = `${range}${suffixInside}`;
@@ -93,7 +95,7 @@ export function convertBibleTextToMarkdownLink(
       })
       .join(',');
 
-    if (keepStrukture) {
+    if (skipStyling) {
       return styledLinks;
     }
 


### PR DESCRIPTION
## Summary

- Fixes multi-range links (e.g. `ps119:1,5-8,50`) not receiving prefix/suffix styling when "Keep current structure" is set
- The condition now only skips styling when re-formatting existing links (`originalText` provided), not when creating new ones
- Adds test coverage for multi-range link styling

Closes #289

## Test plan

- [x] Existing tests pass (504/504)
- [x] New tests cover: outside prefix/suffix, inside prefix/suffix, and skip-styling-on-re-link scenarios
- [x] Manual verification: set prefixes/suffixes in settings, create a multi-range link via `/b ps119:1,5-8,50`, confirm styling is applied