### PR TITLE
chore: remove ignored pnpm.onlyBuiltDependencies from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,13 +67,6 @@
     "yaml": "^2.9.0"
   },
   "packageManager": "pnpm@11.1.2",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@swc/core",
-      "esbuild",
-      "unrs-resolver"
-    ]
-  },
   "dependencies": {
     "fflate": "^0.8.3"
   }


### PR DESCRIPTION
pnpm 11 no longer reads the pnpm field in package.json and warned on every install. The build-script allowlist is already active via allowBuilds in pnpm-workspace.yaml, so the stale key only suggested a protection that was not being applied from this location.